### PR TITLE
Use trans.Reader in WeakRead and introduce GC

### DIFF
--- a/db.go
+++ b/db.go
@@ -78,12 +78,15 @@ func OpenWith(ctx context.Context, name string, b backend.Backend, opts Options)
 	tl := storage.NewTLogger(opts.Clock, global, local, name)
 	tmon := trans.NewMonitor(opts.Clock, local, tl, bg)
 	locker := trans.NewLocker(local, global, tl, opts.Clock, tmon)
+	gc := trans.NewGC(opts.Clock, bg, tl, opts.Logger)
+	gc.Start(ctx)
 	ta := trans.NewAlgo(
 		opts.Clock,
 		global,
 		local,
 		locker,
 		tmon,
+		gc,
 		bg,
 		opts.Logger,
 	)
@@ -94,6 +97,7 @@ func OpenWith(ctx context.Context, name string, b backend.Backend, opts Options)
 		cache:      cache,
 		background: bg,
 		tmon:       tmon,
+		gc:         gc,
 		algo:       ta,
 		clock:      opts.Clock,
 		logger:     opts.Logger,
@@ -109,6 +113,7 @@ type DB struct {
 	cache      *cache.Cache
 	background *concurr.Background
 	tmon       *trans.Monitor
+	gc         *trans.GC
 	algo       trans.Algo
 	clock      clockwork.Clock
 	logger     *slog.Logger

--- a/internal/trans/gc.go
+++ b/internal/trans/gc.go
@@ -1,0 +1,105 @@
+package trans
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/mbrt/glassdb/internal/concurr"
+	"github.com/mbrt/glassdb/internal/data"
+	"github.com/mbrt/glassdb/internal/storage"
+)
+
+const (
+	cleanupInterval = time.Minute
+	sizeLimit       = 1024
+)
+
+func NewGC(
+	clock clockwork.Clock,
+	bg *concurr.Background,
+	tl storage.TLogger,
+	log *slog.Logger,
+) *GC {
+	return &GC{
+		clock: clock,
+		bg:    bg,
+		tl:    tl,
+		log:   log,
+	}
+}
+
+type GC struct {
+	clock clockwork.Clock
+	bg    *concurr.Background
+	tl    storage.TLogger
+	log   *slog.Logger
+	items []cleanupItem
+	m     sync.Mutex
+}
+
+func (g *GC) Start(ctx context.Context) {
+	g.bg.Go(ctx, func(ctx context.Context) {
+		tick := g.clock.NewTicker(cleanupInterval)
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-tick.Chan():
+				g.cleanupRound(ctx)
+			}
+		}
+	})
+}
+
+func (g *GC) ScheduleTxCleanup(txid data.TxID) {
+	t := g.clock.Now().Add(cleanupInterval)
+
+	g.m.Lock()
+	// Avoid growing indefinitely.
+	if len(g.items) > sizeLimit {
+		g.m.Unlock()
+		g.log.Debug("gc: too many items to cleanup")
+		return
+	}
+	g.items = append(g.items, cleanupItem{
+		dueTime: t,
+		txID:    txid,
+	})
+	g.m.Unlock()
+}
+
+func (g *GC) cleanupRound(ctx context.Context) {
+	now := g.clock.Now()
+	toCleanup := g.filterDueItems(now)
+
+	for _, item := range toCleanup {
+		if err := g.tl.Delete(ctx, item.txID); err != nil {
+			g.log.Warn("failed to delete transaction log", "err", err, "txid", item.txID)
+		}
+	}
+}
+
+func (g *GC) filterDueItems(now time.Time) []cleanupItem {
+	g.m.Lock()
+	defer g.m.Unlock()
+
+	var toCleanup []cleanupItem
+	i := 0
+	for ; i < len(g.items); i++ {
+		if g.items[i].dueTime.After(now) {
+			break
+		}
+		toCleanup = append(toCleanup, g.items[i])
+	}
+	g.items = g.items[i:]
+	return toCleanup
+}
+
+type cleanupItem struct {
+	dueTime time.Time
+	txID    data.TxID
+}

--- a/internal/trans/gc_test.go
+++ b/internal/trans/gc_test.go
@@ -1,0 +1,90 @@
+package trans
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mbrt/glassdb/backend"
+	"github.com/mbrt/glassdb/backend/memory"
+	"github.com/mbrt/glassdb/internal/cache"
+	"github.com/mbrt/glassdb/internal/concurr"
+	"github.com/mbrt/glassdb/internal/data"
+	"github.com/mbrt/glassdb/internal/errors"
+	"github.com/mbrt/glassdb/internal/storage"
+	"github.com/mbrt/glassdb/internal/testkit"
+)
+
+const conditionTimeout = time.Second
+
+func TestGC(t *testing.T) {
+	gc, tctx := newTestGC(t)
+	start := tctx.clock.Now()
+	txid := data.TxID([]byte("tx1"))
+
+	// Create a transaction log.
+	_, err := gc.tl.Set(tctx.ctx, storage.TxLog{
+		ID:        txid,
+		Timestamp: start,
+		Status:    storage.TxCommitStatusOK,
+	})
+	assert.NoError(t, err)
+
+	// Make sure the log is there.
+	tl, err := gc.tl.Get(tctx.ctx, txid)
+	assert.NoError(t, err)
+	assert.Equal(t, txid, tl.ID)
+
+	gc.ScheduleTxCleanup(txid)
+
+	// Wait for the GC to run.
+	tctx.clock.Sleep(cleanupInterval * 2)
+
+	waitForCondition(t, func() bool {
+		_, err := gc.tl.Get(tctx.ctx, txid)
+		return errors.Is(err, backend.ErrNotFound)
+	})
+}
+
+type gcTestContext struct {
+	ctx   context.Context
+	clock clockwork.Clock
+}
+
+func newTestGC(t *testing.T) (*GC, gcTestContext) {
+	t.Helper()
+
+	// It's important to close the context at the end to stop
+	// any background tasks.
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	clock := testkit.NewAcceleratedClock(clockMultiplier)
+	log := slog.New(nilHandler{})
+	cache := cache.New(1024)
+	local := storage.NewLocal(cache, clock)
+	global := storage.NewGlobal(memory.New(), local, clock)
+	tlogger := storage.NewTLogger(clock, global, local, testCollName)
+	background := concurr.NewBackground()
+	gc := NewGC(clock, background, tlogger, log)
+	gc.Start(ctx)
+
+	return gc, gcTestContext{
+		ctx, clock,
+	}
+}
+
+func waitForCondition(t *testing.T, cond func() bool) {
+	t.Helper()
+	for start := time.Now(); time.Since(start) < conditionTimeout; {
+		if cond() {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Errorf("condition not met within 1s")
+}


### PR DESCRIPTION
This speeds things up considerably in case of no cache hit, as it avoids a full transaction in all cases. It may return a slightly stale value but never incur a lock.

Also introduce garbage collection for committed transaction logs, after all locks are released.