### PR TITLE
Fix lost update from caching unresolved single-RW writes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ make test
 
 - Test interfaces and intended behavior instead of internals
 - Prefer integration tests to mocks as much as possible
+- Add deterministic tests for bugs discovered by fuzz tests
 
 ### Formatting Code
 

--- a/backend/middleware/delaybackend.go
+++ b/backend/middleware/delaybackend.go
@@ -293,7 +293,11 @@ func (b *DelayBackend) List(ctx context.Context, dirPath string) (backend.ListIt
 }
 
 func (b *DelayBackend) backoff(ctx context.Context, path string) error {
-	r := concurr.RetryOptions(b.retryDelay, b.retryDelay*10)
+	r := concurr.NewRetrier(concurr.RetryConfig{
+		InitialInterval: b.retryDelay,
+		MaxInterval:     b.retryDelay * 10,
+		Jitter:          true,
+	})
 	return r.Retry(ctx, func() error {
 		if !b.rlimit.TryAcquireToken(path) {
 			return errBackoff

--- a/backend/middleware/delaybackend.go
+++ b/backend/middleware/delaybackend.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"context"
+	crand "crypto/rand"
 	"errors"
 	"math"
 	"math/rand"
@@ -296,7 +297,7 @@ func (b *DelayBackend) backoff(ctx context.Context, path string) error {
 	r := concurr.NewRetrier(concurr.RetryConfig{
 		InitialInterval: b.retryDelay,
 		MaxInterval:     b.retryDelay * 10,
-		Jitter:          true,
+		Rand:            crand.Reader,
 	})
 	return r.Retry(ctx, func() error {
 		if !b.rlimit.TryAcquireToken(path) {

--- a/db.go
+++ b/db.go
@@ -4,6 +4,7 @@ package glassdb
 
 import (
 	"context"
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"io"
@@ -67,9 +68,11 @@ type RetryOptions struct {
 	// default.
 	MaxInterval time.Duration
 	// DisableJitter turns off interval randomization. Jitter is enabled by
-	// default because it spreads retries to avoid thundering-herd contention;
-	// disable it only when deterministic retry timing is required, e.g. in
-	// tests, since it draws from the process-global RNG.
+	// default because it spreads retries to avoid thundering-herd contention,
+	// and draws from the DB's Rand source. Disable it only when deterministic
+	// retry timing is required, e.g. in tests: the retrier runs in background
+	// goroutines whose interleaving testing/synctest does not serialize, so
+	// jitter reads from a seeded Rand source would not be reproducible.
 	DisableJitter bool
 }
 
@@ -94,7 +97,7 @@ func OpenWith(ctx context.Context, name string, b backend.Backend, opts Options)
 	local := storage.NewLocal(cache)
 	global := storage.NewGlobal(backend, local)
 	tl := storage.NewTLogger(global, local, name)
-	tmon := trans.NewMonitor(local, tl, bg, newRetrier(opts.Retry))
+	tmon := trans.NewMonitor(local, tl, bg, newRetrier(opts.Retry, opts.Rand))
 	locker := trans.NewLocker(local, global, tl, tmon)
 	gc := trans.NewGC(bg, tl, opts.Logger)
 	gc.Start(ctx)
@@ -184,20 +187,20 @@ func (d *DB) openCollection(prefix string) Collection {
 	return Collection{prefix, global, local, d.algo, d}
 }
 
-// newRetrier builds the internal retrier from the public retry options,
-// filling unset (non-positive) intervals with defaults.
-func newRetrier(o RetryOptions) concurr.Retrier {
-	def := concurr.DefaultRetryConfig()
+// newRetrier builds the internal retrier from the public retry options.
+// Unset (non-positive) intervals are filled with defaults by NewRetrier. The
+// jitter randomness reuses the DB's Rand source (defaulting to crypto/rand)
+// unless jitter is disabled.
+func newRetrier(o RetryOptions, rnd io.Reader) concurr.Retrier {
 	cfg := concurr.RetryConfig{
 		InitialInterval: o.InitialInterval,
 		MaxInterval:     o.MaxInterval,
-		Jitter:          !o.DisableJitter,
 	}
-	if cfg.InitialInterval <= 0 {
-		cfg.InitialInterval = def.InitialInterval
-	}
-	if cfg.MaxInterval <= 0 {
-		cfg.MaxInterval = def.MaxInterval
+	if !o.DisableJitter {
+		cfg.Rand = rnd
+		if cfg.Rand == nil {
+			cfg.Rand = rand.Reader
+		}
 	}
 	return concurr.NewRetrier(cfg)
 }

--- a/db.go
+++ b/db.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"regexp"
 	"sync"
@@ -14,6 +15,7 @@ import (
 	"github.com/mbrt/glassdb/backend"
 	"github.com/mbrt/glassdb/internal/cache"
 	"github.com/mbrt/glassdb/internal/concurr"
+	"github.com/mbrt/glassdb/internal/data"
 	"github.com/mbrt/glassdb/internal/data/paths"
 	"github.com/mbrt/glassdb/internal/storage"
 	"github.com/mbrt/glassdb/internal/trace"
@@ -25,21 +27,50 @@ var nameRegexp = regexp.MustCompile(`^[a-zA-Z0-9]+$`)
 // DefaultOptions provides the options used by `Open`. They should be a good
 // middle ground for a production deployment.
 func DefaultOptions() Options {
+	rc := concurr.DefaultRetryConfig()
 	return Options{
 		Logger:    slog.Default(),
 		CacheSize: 5012 * 1024 * 1024, // 512 MiB
+		Retry: RetryOptions{
+			InitialInterval: rc.InitialInterval,
+			MaxInterval:     rc.MaxInterval,
+		},
 	}
 }
 
 // Options makes it possible to tweak a client DB.
-//
-// TODO: Add retry timing options.
 type Options struct {
 	Logger *slog.Logger
 	// Cache size is the number of bytes dedicated to caching objects and
 	// and metadata. Setting this too small may impact performance, as
 	// more calls to the backend would be necessary.
 	CacheSize int
+	// Retry tunes the exponential backoff used to retry transient
+	// transaction-coordination operations.
+	Retry RetryOptions
+	// Rand is the source of randomness for transaction-ID prefixes. A nil
+	// value uses crypto/rand. Deterministic tests can supply a seeded reader
+	// to make transaction IDs (and thus a run) reproducible; the transaction
+	// priority still comes from the clock. Rand must be safe for concurrent
+	// use.
+	Rand io.Reader
+}
+
+// RetryOptions tunes the exponential backoff the DB uses when retrying
+// transient transaction-coordination operations, such as polling a peer
+// transaction's commit status or writing a transaction's final log.
+type RetryOptions struct {
+	// InitialInterval is the delay before the first retry; it grows
+	// exponentially up to MaxInterval. A non-positive value selects a default.
+	InitialInterval time.Duration
+	// MaxInterval caps the per-retry delay. A non-positive value selects a
+	// default.
+	MaxInterval time.Duration
+	// DisableJitter turns off interval randomization. Jitter is enabled by
+	// default because it spreads retries to avoid thundering-herd contention;
+	// disable it only when deterministic retry timing is required, e.g. in
+	// tests, since it draws from the process-global RNG.
+	DisableJitter bool
 }
 
 // Open opens a database with the given name using default options.
@@ -63,7 +94,7 @@ func OpenWith(ctx context.Context, name string, b backend.Backend, opts Options)
 	local := storage.NewLocal(cache)
 	global := storage.NewGlobal(backend, local)
 	tl := storage.NewTLogger(global, local, name)
-	tmon := trans.NewMonitor(local, tl, bg)
+	tmon := trans.NewMonitor(local, tl, bg, newRetrier(opts.Retry))
 	locker := trans.NewLocker(local, global, tl, tmon)
 	gc := trans.NewGC(bg, tl, opts.Logger)
 	gc.Start(ctx)
@@ -75,6 +106,7 @@ func OpenWith(ctx context.Context, name string, b backend.Backend, opts Options)
 		gc,
 		bg,
 		opts.Logger,
+		data.NewTxIDSource(opts.Rand),
 	)
 
 	res := &DB{
@@ -150,6 +182,24 @@ func (d *DB) openCollection(prefix string) Collection {
 	local := storage.NewLocal(d.cache)
 	global := storage.NewGlobal(d.backend, local)
 	return Collection{prefix, global, local, d.algo, d}
+}
+
+// newRetrier builds the internal retrier from the public retry options,
+// filling unset (non-positive) intervals with defaults.
+func newRetrier(o RetryOptions) concurr.Retrier {
+	def := concurr.DefaultRetryConfig()
+	cfg := concurr.RetryConfig{
+		InitialInterval: o.InitialInterval,
+		MaxInterval:     o.MaxInterval,
+		Jitter:          !o.DisableJitter,
+	}
+	if cfg.InitialInterval <= 0 {
+		cfg.InitialInterval = def.InitialInterval
+	}
+	if cfg.MaxInterval <= 0 {
+		cfg.MaxInterval = def.MaxInterval
+	}
+	return concurr.NewRetrier(cfg)
 }
 
 func (d *DB) txImpl(ctx context.Context, fn func(tx *Tx) error, stats *Stats) (err error) {

--- a/docs/adr/007-single-rw-cache-lost-update.md
+++ b/docs/adr/007-single-rw-cache-lost-update.md
@@ -1,0 +1,119 @@
+# ADR-007: Fix lost update from caching unresolved single-RW writes
+
+## Status
+
+Accepted
+
+## Context
+
+`FuzzConcurrentTx` (the serializability fuzzer) found a strict-serializability
+violation: two clients incrementing the same keys could lose an update —
+e.g. key `k1` ended at `4` when every committed increment summed to `7`. One
+transaction's committed write was silently overwritten by another transaction
+that had read a stale value yet passed commit-time validation.
+
+### Root cause
+
+The bug is an interaction between two existing mechanisms:
+
+1. **The single read-modify-write fast path** (`commitSingleRW`). A transaction
+   that only reads and writes a single key commits with one conditional backend
+   write and writes **no transaction-log object** (`_t/<tx-id>`). This is a large
+   latency win, but it means the transaction's commit status and committed value
+   cannot be recovered from the log afterwards.
+
+2. **Validation refreshing the local cache.** When a transaction reads a value
+   and then finds, at validation time, that the key was written by someone else,
+   `validateLockedRead` / `validateReadNotFound` ask `Monitor.CommittedValue` for
+   the writer's committed value and store it in the local cache, tagged with that
+   writer's ID, so the retry can revalidate quickly.
+
+When the relevant writer committed through the single-RW fast path,
+`CommittedValue` has no log to consult and returns a non-`OK` status with an
+**unresolved / empty value**. The old code only skipped the cache update when the
+value was literally `NotWritten`; for an unresolved-but-present status it cached
+the *guessed* value bytes paired with the *real* writer ID.
+
+That produces a poisoned cache entry: value bytes from one version, writer tag
+from a newer version. A later single-RW commit on that key validates with
+`checkReadVersionUnlocked`, which trusts the entry because its writer tag matches
+the live `last-writer` — even though the value is stale. The conditional write
+then succeeds and clobbers the newer value: a lost update, and a strict
+serializability violation.
+
+Wound-wait (ADR-002) did not introduce the bug but made it far more frequent: the
+extra aborts and restarts under contention multiply the number of times a
+transaction validates against a single-RW writer's key.
+
+### Why it was hard to reproduce
+
+The fuzzer was effectively non-deterministic: replaying a saved failing input
+reproduced the failure well under 10% of the time, so it could neither be
+minimized nor turned into a regression test. Three independent sources of
+nondeterminism, none of them controlled by `testing/synctest`, were responsible:
+
+- **Random transaction-ID prefixes.** `data.NewTId` draws its prefix from
+  `crypto/rand`, so IDs (and therefore tx-log object keys, and the order tied to
+  them) differed on every run.
+- **Go map iteration order.** Several commit-path steps built slices by ranging
+  over a map, so the order of backend operations a transaction issued varied run
+  to run.
+- **Backoff jitter.** `cenkalti/backoff` randomizes retry intervals using the
+  process-global `math/rand`, which `synctest` does not virtualize, so retry
+  timing — and thus the interleaving — drifted.
+
+## Decision
+
+### Fix the lost update
+
+In `validateLockedRead` and `validateReadNotFound`, only refresh the local cache
+with a writer's value when `CommittedValue` resolved it **authoritatively**
+(`Status == OK` and the value is written). Otherwise — the writer used the
+single-RW fast path and its value is unresolvable from the log — do not cache a
+guessed value. `validateLockedRead` instead invalidates the stale entry
+(`local.MarkValueOutated`) so the retry re-reads the authoritative value straight
+from storage; `validateReadNotFound` simply retries without touching the cache.
+
+This removes the only paths that paired a value with a writer that did not
+produce it, so `checkReadVersionUnlocked` can no longer be fooled into accepting a
+stale read. Correctness comes from re-reading storage on retry, which already
+returns the genuine committed value (its `last-writer` tag still names the
+single-RW writer), so no extra log lookup or backend round-trip is needed on the
+common path.
+
+### Make the fuzzer deterministic
+
+Determinism is a prerequisite for diagnosing and regression-testing concurrency
+bugs, so the three nondeterminism sources above were removed:
+
+- **Injectable ID source.** `data.NewTIDFromSource` / `RenewTIDFromSource` draw
+  the random prefix from a caller-supplied `io.Reader`, and `trans.CtxWithIDSource`
+  threads one through the context. The timestamp (and therefore wound-wait
+  priority) is untouched, so this changes only the prefix entropy, not which
+  schedules the fuzzer explores. Production still uses `crypto/rand`.
+- **Stable ordering.** Commit-path slices built from maps are now sorted by path
+  (`initValidation`, `collectionsLocks`, `tlocker.LockedPaths`), so the sequence
+  of backend operations no longer depends on map iteration order.
+- **No jitter.** `concurr.RetryOptions` sets `RandomizationFactor = 0`. Progress
+  under contention is guaranteed by wound-wait and the serial-locking fallback,
+  not by jitter, so removing it is safe.
+
+The two context keys in `internal/trans` were also changed from bare `struct{}{}`
+values (which compare equal, so they collided) to a private `ctxKey` type with
+distinct constants.
+
+## Consequences
+
+- The fuzzer no longer reproduces the lost update: a 120k-schedule replay harness
+  and a 3-minute (~1.1M-exec) fuzz run both pass, where they previously failed.
+- The local cache can no longer hold a value whose bytes and writer tag come from
+  different versions via the validation paths, closing the lost-update hole.
+- On the uncommon path where a single-RW writer's value is unresolvable, a
+  transaction does one extra retry (re-reading from storage) instead of trusting a
+  cached guess. This trades a small amount of work under contention for
+  correctness.
+- The transaction-ID prefix is now an injectable seam used by deterministic tests;
+  the rest of the codebase is unaffected.
+- Backoff retries are now strictly exponential (no jitter). If thundering-herd
+  retries ever become a concern, jitter should be reintroduced behind a
+  test-controllable RNG rather than the global `math/rand`.

--- a/docs/adr/007-single-rw-cache-lost-update.md
+++ b/docs/adr/007-single-rw-cache-lost-update.md
@@ -86,17 +86,23 @@ common path.
 Determinism is a prerequisite for diagnosing and regression-testing concurrency
 bugs, so the three nondeterminism sources above were removed:
 
-- **Injectable ID source.** `data.NewTIDFromSource` / `RenewTIDFromSource` draw
-  the random prefix from a caller-supplied `io.Reader`, and `trans.CtxWithIDSource`
-  threads one through the context. The timestamp (and therefore wound-wait
-  priority) is untouched, so this changes only the prefix entropy, not which
-  schedules the fuzzer explores. Production still uses `crypto/rand`.
+- **Injectable ID source.** `data.TxIDSource` wraps an `io.Reader` (defaulting to
+  `crypto/rand`) and mints IDs via `New` / `Renew`; `Renew` preserves the
+  timestamp (and therefore wound-wait priority) so only the prefix entropy
+  changes. The source is configured once per DB through `glassdb.Options.Rand`
+  and held by `Algo`, the same construction-time plumbing used for retry timing
+  — no per-call context lookup. The fuzzer opens each DB with a seeded reader.
+  (`trans.CtxWithTxID` remains a separate, minimal context override used only by
+  the wound-wait tests to pin a transaction's priority.)
 - **Stable ordering.** Commit-path slices built from maps are now sorted by path
   (`initValidation`, `collectionsLocks`, `tlocker.LockedPaths`), so the sequence
   of backend operations no longer depends on map iteration order.
-- **No jitter.** `concurr.RetryOptions` sets `RandomizationFactor = 0`. Progress
-  under contention is guaranteed by wound-wait and the serial-locking fallback,
-  not by jitter, so removing it is safe.
+- **Jitter as a retry option.** Backoff jitter is kept in production (it spreads
+  retries to avoid thundering-herd contention) but draws from the process-global
+  `math/rand`, which `synctest` does not virtualize. Whether to use jitter is a
+  field of `concurr.RetryConfig`, set once when the `Retrier` is constructed and
+  plumbed up to `glassdb.Options.Retry` (`RetryOptions.DisableJitter`). The
+  fuzzer opens its DBs with jitter disabled; production keeps the default.
 
 The two context keys in `internal/trans` were also changed from bare `struct{}{}`
 values (which compare equal, so they collided) to a private `ctxKey` type with
@@ -112,8 +118,12 @@ distinct constants.
   transaction does one extra retry (re-reading from storage) instead of trusting a
   cached guess. This trades a small amount of work under contention for
   correctness.
-- The transaction-ID prefix is now an injectable seam used by deterministic tests;
-  the rest of the codebase is unaffected.
-- Backoff retries are now strictly exponential (no jitter). If thundering-herd
-  retries ever become a concern, jitter should be reintroduced behind a
-  test-controllable RNG rather than the global `math/rand`.
+- The transaction-ID prefix is now an injectable seam (`glassdb.Options.Rand`
+  backed by `data.TxIDSource`) used by deterministic tests; production leaves it
+  unset and gets `crypto/rand`.
+- Production backoff keeps its jitter; only DBs opened with
+  `Options.Retry.DisableJitter` (currently just the fuzzer) get deterministic
+  retry timing. Retry timing (initial/max interval and jitter) is now a public
+  DB option, resolving the previous "add retry timing options" TODO. If
+  deterministic jitter is ever needed, it should be reintroduced behind a
+  per-retrier RNG rather than the global `math/rand`.

--- a/docs/adr/007-single-rw-cache-lost-update.md
+++ b/docs/adr/007-single-rw-cache-lost-update.md
@@ -58,7 +58,7 @@ nondeterminism, none of them controlled by `testing/synctest`, were responsible:
 - **Go map iteration order.** Several commit-path steps built slices by ranging
   over a map, so the order of backend operations a transaction issued varied run
   to run.
-- **Backoff jitter.** `cenkalti/backoff` randomizes retry intervals using the
+- **Backoff jitter.** `cenkalti/backoff` randomized retry intervals using the
   process-global `math/rand`, which `synctest` does not virtualize, so retry
   timing — and thus the interleaving — drifted.
 
@@ -97,12 +97,25 @@ bugs, so the three nondeterminism sources above were removed:
 - **Stable ordering.** Commit-path slices built from maps are now sorted by path
   (`initValidation`, `collectionsLocks`, `tlocker.LockedPaths`), so the sequence
   of backend operations no longer depends on map iteration order.
-- **Jitter as a retry option.** Backoff jitter is kept in production (it spreads
-  retries to avoid thundering-herd contention) but draws from the process-global
-  `math/rand`, which `synctest` does not virtualize. Whether to use jitter is a
-  field of `concurr.RetryConfig`, set once when the `Retrier` is constructed and
-  plumbed up to `glassdb.Options.Retry` (`RetryOptions.DisableJitter`). The
-  fuzzer opens its DBs with jitter disabled; production keeps the default.
+- **Inlined backoff with an injectable jitter source.** The minimal exponential
+  backoff `cenkalti/backoff` provided is now inlined in `internal/concurr`
+  (`Retrier`, `RetryConfig`, `Permanent`), dropping the dependency and, more
+  importantly, the hidden coupling to the process-global `math/rand`. Jitter now
+  draws from a `RetryConfig.Rand io.Reader` (nil disables it), which
+  `glassdb.Options` wires to the DB's own `Rand` source — the same knob used for
+  transaction IDs — defaulting to `crypto/rand`. Jitter stays on in production
+  (it spreads retries to avoid thundering-herd contention); the fuzzer opens its
+  DBs with `RetryOptions.DisableJitter`.
+
+  Re-enabling jitter does **not** let the fuzzer keep it on, even with a seeded
+  `Rand`. The retrier runs inside background goroutines (the remote-status poll
+  worker spawned by `Monitor.WaitTx`, and the tx-refresh worker), and
+  `testing/synctest` does not serialize the interleaving of concurrently-runnable
+  goroutines. Those goroutines would therefore consume jitter bytes from the
+  shared seeded reader in a run-dependent order, so wake-up times — and the
+  schedule — would drift again. With jitter off, `NextBackOff` consumes no
+  randomness and intervals are purely exponential, which is what keeps replay
+  deterministic.
 
 The two context keys in `internal/trans` were also changed from bare `struct{}{}`
 values (which compare equal, so they collided) to a private `ctxKey` type with
@@ -112,6 +125,12 @@ distinct constants.
 
 - The fuzzer no longer reproduces the lost update: a 120k-schedule replay harness
   and a 3-minute (~1.1M-exec) fuzz run both pass, where they previously failed.
+- `TestSingleRWLostUpdate` (in `internal/trans/algo_test.go`) is a deterministic
+  regression test that recreates the exact poisoning sequence: a logless
+  single-RW writer, a victim with a stale read, and a pending lock that forces
+  validation down the unresolvable branch. It asserts the victim subsequently
+  reads the authoritative value rather than the cached guess; it fails against
+  the pre-fix validation code and passes after it.
 - The local cache can no longer hold a value whose bytes and writer tag come from
   different versions via the validation paths, closing the lost-update hole.
 - On the uncommon path where a single-RW writer's value is unresolvable, a
@@ -121,9 +140,3 @@ distinct constants.
 - The transaction-ID prefix is now an injectable seam (`glassdb.Options.Rand`
   backed by `data.TxIDSource`) used by deterministic tests; production leaves it
   unset and gets `crypto/rand`.
-- Production backoff keeps its jitter; only DBs opened with
-  `Options.Retry.DisableJitter` (currently just the fuzzer) get deterministic
-  retry timing. Retry timing (initial/max interval and jitter) is now a public
-  DB option, resolving the previous "add retry timing options" TODO. If
-  deterministic jitter is ever needed, it should be reintroduced behind a
-  per-retrier RNG rather than the global `math/rand`.

--- a/docs/adr/008-fuzz-determinism-regression-test.md
+++ b/docs/adr/008-fuzz-determinism-regression-test.md
@@ -1,0 +1,89 @@
+# ADR-008: Regression test for fuzz outcome determinism
+
+## Status
+
+Accepted
+
+## Context
+
+ADR-007 removed three gratuitous sources of nondeterminism from the
+serializability fuzzer (`FuzzConcurrentTx`) so that a failing schedule could be
+minimized and turned into a deterministic regression test: random
+transaction-ID prefixes, map-iteration order in commit-path slices, and backoff
+jitter drawn from the process-global `math/rand`.
+
+We wanted a standing test that guards those settings against regression. The
+obvious approach — replay a schedule twice and assert the two runs issue an
+identical sequence of backend operations — does **not** work, and understanding
+why shaped this decision.
+
+The algorithm is not, and is not meant to be, deterministic at the level of
+backend-operation ordering:
+
+- Multi-key work is dispatched through concurrent fan-out
+  (`internal/concurr.Fanout`, backed by `errgroup`), and the fuzz workload runs
+  two clients in parallel. The interleaving of those goroutines is the behaviour
+  under test.
+- `testing/synctest` virtualizes the clock but schedules **real** goroutines;
+  the Go runtime does not order concurrently-runnable goroutines
+  deterministically. Replaying the same schedule diverges in operation order
+  even at `GOMAXPROCS=1`.
+- The `ScheduledBackend` only *influences* interleaving by delaying each
+  operation; when two operations draw equal delays, or when goroutines
+  synchronize on something other than a backend call, the tie is broken
+  nondeterministically. Because the fake clock advances based on which
+  goroutines are blocked, the priority timestamp baked into each transaction ID
+  (`internal/data.TxID`) — and therefore tx-log object paths and object
+  versions — also differs run to run.
+
+Byte-for-byte execution determinism would require a different architecture
+entirely: a deterministic-simulation harness with a single cooperative
+scheduler that intercepts every concurrency/sync point and picks the next
+goroutine from the fuzz input (as FoundationDB and TigerBeetle do). That is a
+large, invasive change and out of scope here.
+
+What the deterministic settings *do* guarantee, together with the
+serializability guarantee, is that a given schedule always commits the **same
+result**. That is the property the fuzzer's invariant check actually depends
+on, and it is exactly what the ADR-007 lost update broke: under contention a
+committed increment could be silently dropped, so the same schedule could commit
+different totals depending on the interleaving.
+
+## Decision
+
+Add `TestConcurrentTxDeterministicOutcome` (in `fuzz_test.go`) as the
+determinism regression test, guarding the committed **outcome** rather than the
+execution trace.
+
+- The two-client workload body was extracted from `fuzzConcurrentTx` into
+  `fuzzConcurrentTxWorkload`, which now returns a `fuzzOutcome` (the committed
+  value of every key plus the increment totals the clients tracked). The fuzzer
+  and the regression test share this exact workload.
+- The test replays a fixed set of schedules many times, each in its own
+  `synctest` bubble, and asserts every replay commits an identical `fuzzOutcome`.
+  Because each replay interleaves the two clients differently, an outcome that
+  depends on the interleaving makes the replays disagree and fails the test.
+- The schedules are chosen to span a range of interleavings, including heavy
+  contention, which is where the aborts, retries, and background
+  status/refresh workers that exercise the relevant code paths occur.
+
+This is a probabilistic guard, like the fuzzer it protects: it cannot prove
+determinism, but replaying several contended schedules many times gives a high
+chance of surfacing a nondeterministic-outcome regression.
+
+## Consequences
+
+- A regression that reintroduces interleaving-dependent committed state (the
+  ADR-007 lost-update class) makes replays of the same schedule disagree and
+  fails the test, in addition to `fuzzConcurrentTxWorkload`'s per-run check that
+  the committed values equal the tracked increments.
+- The test is fast and deterministic in CI: the committed result is fixed by the
+  workload, so a correct implementation always passes.
+- The test does **not** guard execution-level reproducibility (operation order,
+  tx-ID timestamps, object versions); those are intentionally nondeterministic
+  and asserting on them would be flaky. It also does not, by itself, catch a
+  change that merely unseeds the ID source or re-enables jitter, since those
+  affect reproducibility rather than the committed outcome; ADR-007 remains the
+  reference for why those knobs exist.
+- `fuzzConcurrentTxWorkload` returning `fuzzOutcome` gives future tests a single
+  reusable definition of the workload's observable result.

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -275,8 +275,10 @@ func initFuzzDB(t testing.TB, b backend.Backend, rng io.Reader) *glassdb.DB {
 	ctx := context.Background()
 	opts := glassdb.DefaultOptions()
 	opts.Logger = slog.New(nilHandler{})
-	// Deterministic transaction IDs and retry timing: both otherwise draw from
-	// RNGs that testing/synctest does not virtualize.
+	// Seed transaction IDs from a deterministic source so a run is
+	// reproducible. Jitter stays off: the retrier runs in background goroutines
+	// whose interleaving testing/synctest does not serialize, so jitter reads
+	// from the seeded source would not be consumed in a reproducible order.
 	opts.Rand = rng
 	opts.Retry.DisableJitter = true
 	db, err := glassdb.OpenWith(ctx, "example", b, opts)

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -45,10 +45,87 @@ func FuzzConcurrentTx(f *testing.F) {
 }
 
 func fuzzConcurrentTx(t *testing.T, schedule []byte) {
-	ctx, cancel := context.WithCancel(context.Background())
-
 	sched := middleware.NewScheduler(schedule, time.Millisecond)
 	b := middleware.NewScheduledBackend(memory.New(), sched)
+	fuzzConcurrentTxWorkload(t, b)
+}
+
+// TestConcurrentTxDeterministicOutcome locks in the determinism the fuzzer
+// relies on. The algorithm deliberately issues backend operations through
+// concurrent fan-out and the two clients run in parallel, so the exact
+// operation interleaving is NOT reproducible (testing/synctest virtualizes the
+// clock but does not serialize concurrently-runnable goroutines). What the
+// deterministic fuzz settings do guarantee — seeded transaction-ID prefixes and
+// disabled backoff jitter (see docs/adr/007 and docs/adr/008) together with the
+// serializability guarantee — is that a given schedule always commits the same
+// result.
+//
+// The test replays each schedule many times. Because every replay interleaves
+// the two clients differently, any regression that lets the committed state
+// depend on that interleaving — e.g. the ADR-007 lost update, where a committed
+// increment could be silently dropped — would make the replays disagree and
+// fail here. fuzzConcurrentTxWorkload additionally checks, on every run, that
+// the committed values equal the increments the clients tracked.
+func TestConcurrentTxDeterministicOutcome(t *testing.T) {
+	t.Parallel()
+
+	// Fixed schedules chosen to drive a range of interleavings, including
+	// heavy contention (which triggers the aborts, retries and background
+	// status/refresh workers where nondeterminism would surface).
+	schedules := map[string][]byte{
+		"all-zero":             make([]byte, 64),
+		"alternating-extremes": {255, 0, 255, 0, 255, 0, 255, 0},
+		"gradual-ramp":         {1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		"uniform-medium":       {128, 128, 128, 128, 128, 128, 128},
+		"mixed":                {7, 200, 13, 0, 255, 64, 1, 99, 128, 3, 240, 17},
+	}
+
+	const replays = 16
+
+	for name, schedule := range schedules {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			reference := runConcurrentTxOutcome(t, schedule)
+			for i := 1; i < replays; i++ {
+				got := runConcurrentTxOutcome(t, schedule)
+				require.Equal(t, reference, got,
+					"replay %d committed a different result than the first run: "+
+						"the schedule's outcome is no longer deterministic", i)
+			}
+		})
+	}
+}
+
+// runConcurrentTxOutcome runs the shared two-client workload for one schedule
+// inside its own synctest bubble and returns the committed outcome.
+func runConcurrentTxOutcome(t *testing.T, schedule []byte) fuzzOutcome {
+	t.Helper()
+	var out fuzzOutcome
+	synctest.Test(t, func(t *testing.T) {
+		sched := middleware.NewScheduler(schedule, time.Millisecond)
+		b := middleware.NewScheduledBackend(memory.New(), sched)
+		out = fuzzConcurrentTxWorkload(t, b)
+	})
+	return out
+}
+
+// fuzzOutcome is the observable committed result of fuzzConcurrentTxWorkload:
+// the final value of every key together with the per-key increment totals the
+// two clients believe they committed. For a given schedule it must be
+// identical on every replay; see TestConcurrentTxDeterministicOutcome.
+type fuzzOutcome struct {
+	Final [3]int64 // committed value of k1, k2, k3 read back after the workload
+	Want  [3]int64 // sum of successful increments both clients tracked per key
+}
+
+// fuzzConcurrentTxWorkload runs the two-client concurrent workload against the
+// given backend and checks the post-conditions. It is the deterministic core
+// shared by the fuzzer (FuzzConcurrentTx) and the determinism regression test
+// (TestConcurrentTxDeterministicOutcome).
+func fuzzConcurrentTxWorkload(t *testing.T, b backend.Backend) fuzzOutcome {
+	ctx, cancel := context.WithCancel(context.Background())
+
 	// Give each DB its own deterministic source of transaction-ID prefixes so a
 	// given schedule reproduces exactly. Distinct seeds keep the two clients'
 	// IDs disjoint; transaction priority comes from the (deterministic) clock,
@@ -159,6 +236,11 @@ func fuzzConcurrentTx(t *testing.T, schedule []byte) {
 	assert.Equal(t, db1k1+db2k1, readInt(v1), "k1 mismatch")
 	assert.Equal(t, db1k2+db2k2, readInt(v2), "k2 mismatch")
 	assert.Equal(t, db1k3+db2k3, readInt(v3), "k3 mismatch")
+
+	return fuzzOutcome{
+		Final: [3]int64{readInt(v1), readInt(v2), readInt(v3)},
+		Want:  [3]int64{db1k1 + db2k1, db1k2 + db2k2, db1k3 + db2k3},
+	}
 }
 
 // fuzzRMW runs n single-key read-modify-write transactions, each

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
+	"math/rand"
+	"sync"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -17,6 +20,7 @@ import (
 	"github.com/mbrt/glassdb/backend"
 	"github.com/mbrt/glassdb/backend/memory"
 	"github.com/mbrt/glassdb/backend/middleware"
+	"github.com/mbrt/glassdb/internal/trans"
 )
 
 const fuzzTxTimeout = 10 * time.Minute
@@ -54,6 +58,13 @@ func fuzzConcurrentTx(t *testing.T, schedule []byte) {
 		db2.Close(ctx)
 	}()
 
+	// Give each DB its own deterministic source of transaction-ID prefixes so a
+	// given schedule reproduces exactly. Distinct seeds keep the two clients'
+	// IDs disjoint; transaction priority comes from the (deterministic) clock,
+	// so this does not bias which schedules the fuzzer explores.
+	ctx1 := trans.CtxWithIDSource(ctx, newDetSource(1))
+	ctx2 := trans.CtxWithIDSource(ctx, newDetSource(2))
+
 	coll1 := db1.Collection([]byte("fuzz-coll"))
 	coll2 := db2.Collection([]byte("fuzz-coll"))
 
@@ -62,9 +73,9 @@ func fuzzConcurrentTx(t *testing.T, schedule []byte) {
 	key3 := []byte("k3")
 
 	// Initialize collection and keys to zero.
-	err := coll1.Create(ctx)
+	err := coll1.Create(ctx1)
 	require.NoError(t, err)
-	err = db1.Tx(ctx, func(tx *glassdb.Tx) error {
+	err = db1.Tx(ctx1, func(tx *glassdb.Tx) error {
 		for _, k := range [][]byte{key1, key2, key3} {
 			if err := tx.Write(coll1, k, writeInt(0)); err != nil {
 				return err
@@ -84,23 +95,23 @@ func fuzzConcurrentTx(t *testing.T, schedule []byte) {
 	g.Go(func() error {
 		var err error
 		// 1. Single-key RMW on k1.
-		db1k1, err = fuzzRMW(ctx, db1, coll1, key1, 3)
+		db1k1, err = fuzzRMW(ctx1, db1, coll1, key1, 3)
 		if err != nil {
 			return fmt.Errorf("db1 rmw k1: %w", err)
 		}
 		// 2. Multi-key RMW on k1+k2.
-		n, err := fuzzMultiRMW(ctx, db1, coll1, key1, key2, 2)
+		n, err := fuzzMultiRMW(ctx1, db1, coll1, key1, key2, 2)
 		if err != nil {
 			return fmt.Errorf("db1 multi-rmw k1+k2: %w", err)
 		}
 		db1k1 += n
 		db1k2 += n
 		// 3. Read-only transaction: read all keys, verify non-negative.
-		if err := fuzzReadOnly(ctx, db1, coll1, key1, key2, key3); err != nil {
+		if err := fuzzReadOnly(ctx1, db1, coll1, key1, key2, key3); err != nil {
 			return fmt.Errorf("db1 read-only: %w", err)
 		}
 		// 4. Single-key RMW on k3.
-		n, err = fuzzRMW(ctx, db1, coll1, key3, 2)
+		n, err = fuzzRMW(ctx1, db1, coll1, key3, 2)
 		if err != nil {
 			return fmt.Errorf("db1 rmw k3: %w", err)
 		}
@@ -112,23 +123,23 @@ func fuzzConcurrentTx(t *testing.T, schedule []byte) {
 	g.Go(func() error {
 		var err error
 		// 1. Single-key RMW on k2.
-		db2k2, err = fuzzRMW(ctx, db2, coll2, key2, 3)
+		db2k2, err = fuzzRMW(ctx2, db2, coll2, key2, 3)
 		if err != nil {
 			return fmt.Errorf("db2 rmw k2: %w", err)
 		}
 		// 2. Multi-key RMW on k2+k3.
-		n, err := fuzzMultiRMW(ctx, db2, coll2, key2, key3, 2)
+		n, err := fuzzMultiRMW(ctx2, db2, coll2, key2, key3, 2)
 		if err != nil {
 			return fmt.Errorf("db2 multi-rmw k2+k3: %w", err)
 		}
 		db2k2 += n
 		db2k3 += n
 		// 3. Read-only transaction: read all keys, verify non-negative.
-		if err := fuzzReadOnly(ctx, db2, coll2, key1, key2, key3); err != nil {
+		if err := fuzzReadOnly(ctx2, db2, coll2, key1, key2, key3); err != nil {
 			return fmt.Errorf("db2 read-only: %w", err)
 		}
 		// 4. Single-key RMW on k1.
-		n, err = fuzzRMW(ctx, db2, coll2, key1, 2)
+		n, err = fuzzRMW(ctx2, db2, coll2, key1, 2)
 		if err != nil {
 			return fmt.Errorf("db2 rmw k1: %w", err)
 		}
@@ -141,11 +152,11 @@ func fuzzConcurrentTx(t *testing.T, schedule []byte) {
 
 	// Verify invariants: final value of each key == total successful
 	// increments from both DBs.
-	v1, err := coll1.ReadStrong(ctx, key1)
+	v1, err := coll1.ReadStrong(ctx1, key1)
 	require.NoError(t, err)
-	v2, err := coll1.ReadStrong(ctx, key2)
+	v2, err := coll1.ReadStrong(ctx1, key2)
 	require.NoError(t, err)
-	v3, err := coll1.ReadStrong(ctx, key3)
+	v3, err := coll1.ReadStrong(ctx1, key3)
 	require.NoError(t, err)
 
 	assert.Equal(t, db1k1+db2k1, readInt(v1), "k1 mismatch")
@@ -242,6 +253,23 @@ func fuzzReadOnly(
 		}
 		return nil
 	})
+}
+
+// newDetSource returns a deterministic, concurrency-safe source of random
+// bytes used to make transaction-ID prefixes reproducible under a fixed seed.
+func newDetSource(seed int64) io.Reader {
+	return &lockedRand{r: rand.New(rand.NewSource(seed))}
+}
+
+type lockedRand struct {
+	mu sync.Mutex
+	r  *rand.Rand
+}
+
+func (l *lockedRand) Read(p []byte) (int, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.r.Read(p)
 }
 
 func initFuzzDB(t testing.TB, b backend.Backend) *glassdb.DB {

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/mbrt/glassdb/backend"
 	"github.com/mbrt/glassdb/backend/memory"
 	"github.com/mbrt/glassdb/backend/middleware"
-	"github.com/mbrt/glassdb/internal/trans"
 )
 
 const fuzzTxTimeout = 10 * time.Minute
@@ -50,20 +49,18 @@ func fuzzConcurrentTx(t *testing.T, schedule []byte) {
 
 	sched := middleware.NewScheduler(schedule, time.Millisecond)
 	b := middleware.NewScheduledBackend(memory.New(), sched)
-	db1 := initFuzzDB(t, b)
-	db2 := initFuzzDB(t, b)
+	// Give each DB its own deterministic source of transaction-ID prefixes so a
+	// given schedule reproduces exactly. Distinct seeds keep the two clients'
+	// IDs disjoint; transaction priority comes from the (deterministic) clock,
+	// so this does not bias which schedules the fuzzer explores. Backoff jitter
+	// (the other RNG-driven source of nondeterminism) is disabled in initFuzzDB.
+	db1 := initFuzzDB(t, b, newDetReader(1))
+	db2 := initFuzzDB(t, b, newDetReader(2))
 	defer func() {
 		cancel()
 		db1.Close(ctx)
 		db2.Close(ctx)
 	}()
-
-	// Give each DB its own deterministic source of transaction-ID prefixes so a
-	// given schedule reproduces exactly. Distinct seeds keep the two clients'
-	// IDs disjoint; transaction priority comes from the (deterministic) clock,
-	// so this does not bias which schedules the fuzzer explores.
-	ctx1 := trans.CtxWithIDSource(ctx, newDetSource(1))
-	ctx2 := trans.CtxWithIDSource(ctx, newDetSource(2))
 
 	coll1 := db1.Collection([]byte("fuzz-coll"))
 	coll2 := db2.Collection([]byte("fuzz-coll"))
@@ -73,9 +70,9 @@ func fuzzConcurrentTx(t *testing.T, schedule []byte) {
 	key3 := []byte("k3")
 
 	// Initialize collection and keys to zero.
-	err := coll1.Create(ctx1)
+	err := coll1.Create(ctx)
 	require.NoError(t, err)
-	err = db1.Tx(ctx1, func(tx *glassdb.Tx) error {
+	err = db1.Tx(ctx, func(tx *glassdb.Tx) error {
 		for _, k := range [][]byte{key1, key2, key3} {
 			if err := tx.Write(coll1, k, writeInt(0)); err != nil {
 				return err
@@ -95,23 +92,23 @@ func fuzzConcurrentTx(t *testing.T, schedule []byte) {
 	g.Go(func() error {
 		var err error
 		// 1. Single-key RMW on k1.
-		db1k1, err = fuzzRMW(ctx1, db1, coll1, key1, 3)
+		db1k1, err = fuzzRMW(ctx, db1, coll1, key1, 3)
 		if err != nil {
 			return fmt.Errorf("db1 rmw k1: %w", err)
 		}
 		// 2. Multi-key RMW on k1+k2.
-		n, err := fuzzMultiRMW(ctx1, db1, coll1, key1, key2, 2)
+		n, err := fuzzMultiRMW(ctx, db1, coll1, key1, key2, 2)
 		if err != nil {
 			return fmt.Errorf("db1 multi-rmw k1+k2: %w", err)
 		}
 		db1k1 += n
 		db1k2 += n
 		// 3. Read-only transaction: read all keys, verify non-negative.
-		if err := fuzzReadOnly(ctx1, db1, coll1, key1, key2, key3); err != nil {
+		if err := fuzzReadOnly(ctx, db1, coll1, key1, key2, key3); err != nil {
 			return fmt.Errorf("db1 read-only: %w", err)
 		}
 		// 4. Single-key RMW on k3.
-		n, err = fuzzRMW(ctx1, db1, coll1, key3, 2)
+		n, err = fuzzRMW(ctx, db1, coll1, key3, 2)
 		if err != nil {
 			return fmt.Errorf("db1 rmw k3: %w", err)
 		}
@@ -123,23 +120,23 @@ func fuzzConcurrentTx(t *testing.T, schedule []byte) {
 	g.Go(func() error {
 		var err error
 		// 1. Single-key RMW on k2.
-		db2k2, err = fuzzRMW(ctx2, db2, coll2, key2, 3)
+		db2k2, err = fuzzRMW(ctx, db2, coll2, key2, 3)
 		if err != nil {
 			return fmt.Errorf("db2 rmw k2: %w", err)
 		}
 		// 2. Multi-key RMW on k2+k3.
-		n, err := fuzzMultiRMW(ctx2, db2, coll2, key2, key3, 2)
+		n, err := fuzzMultiRMW(ctx, db2, coll2, key2, key3, 2)
 		if err != nil {
 			return fmt.Errorf("db2 multi-rmw k2+k3: %w", err)
 		}
 		db2k2 += n
 		db2k3 += n
 		// 3. Read-only transaction: read all keys, verify non-negative.
-		if err := fuzzReadOnly(ctx2, db2, coll2, key1, key2, key3); err != nil {
+		if err := fuzzReadOnly(ctx, db2, coll2, key1, key2, key3); err != nil {
 			return fmt.Errorf("db2 read-only: %w", err)
 		}
 		// 4. Single-key RMW on k1.
-		n, err = fuzzRMW(ctx2, db2, coll2, key1, 2)
+		n, err = fuzzRMW(ctx, db2, coll2, key1, 2)
 		if err != nil {
 			return fmt.Errorf("db2 rmw k1: %w", err)
 		}
@@ -152,11 +149,11 @@ func fuzzConcurrentTx(t *testing.T, schedule []byte) {
 
 	// Verify invariants: final value of each key == total successful
 	// increments from both DBs.
-	v1, err := coll1.ReadStrong(ctx1, key1)
+	v1, err := coll1.ReadStrong(ctx, key1)
 	require.NoError(t, err)
-	v2, err := coll1.ReadStrong(ctx1, key2)
+	v2, err := coll1.ReadStrong(ctx, key2)
 	require.NoError(t, err)
-	v3, err := coll1.ReadStrong(ctx1, key3)
+	v3, err := coll1.ReadStrong(ctx, key3)
 	require.NoError(t, err)
 
 	assert.Equal(t, db1k1+db2k1, readInt(v1), "k1 mismatch")
@@ -255,9 +252,10 @@ func fuzzReadOnly(
 	})
 }
 
-// newDetSource returns a deterministic, concurrency-safe source of random
-// bytes used to make transaction-ID prefixes reproducible under a fixed seed.
-func newDetSource(seed int64) io.Reader {
+// newDetReader returns a deterministic, concurrency-safe source of random bytes
+// used as a DB's transaction-ID prefix source so a given schedule reproduces
+// exactly under a fixed seed.
+func newDetReader(seed int64) io.Reader {
 	return &lockedRand{r: rand.New(rand.NewSource(seed))}
 }
 
@@ -272,11 +270,15 @@ func (l *lockedRand) Read(p []byte) (int, error) {
 	return l.r.Read(p)
 }
 
-func initFuzzDB(t testing.TB, b backend.Backend) *glassdb.DB {
+func initFuzzDB(t testing.TB, b backend.Backend, rng io.Reader) *glassdb.DB {
 	t.Helper()
 	ctx := context.Background()
 	opts := glassdb.DefaultOptions()
 	opts.Logger = slog.New(nilHandler{})
+	// Deterministic transaction IDs and retry timing: both otherwise draw from
+	// RNGs that testing/synctest does not virtualize.
+	opts.Rand = rng
+	opts.Retry.DisableJitter = true
 	db, err := glassdb.OpenWith(ctx, "example", b, opts)
 	if err != nil {
 		t.Fatalf("creating DB: %v", err)

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.18
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.102.1
 	github.com/aws/smithy-go v1.26.0
-	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/googleapis/gax-go/v2 v2.19.0
 	github.com/gorilla/mux v1.8.1
 	github.com/johannesboyne/gofakes3 v0.0.0-20260208201424-4c385a1f6a73

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,6 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.42.2 h1:XKnxlM4KZH1gktcsh3zSWc7GW4Ki
 github.com/aws/aws-sdk-go-v2/service/sts v1.42.2/go.mod h1:KJYmkQaFB3SUW2j3aBkPsxNmAb4ZsSOvbvCpuxzHJA0=
 github.com/aws/smithy-go v1.26.0 h1:9ouqbi+NyKP7fV3Te7UElCwdAb6Y8uk7LGwPE5tVe/s=
 github.com/aws/smithy-go v1.26.0/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
-github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
-github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cevatbarisyilmaz/ara v0.0.4 h1:SGH10hXpBJhhTlObuZzTuFn1rrdmjQImITXnZVPSodc=

--- a/hack/autoresearch/baseline.json
+++ b/hack/autoresearch/baseline.json
@@ -1,0 +1,104 @@
+{
+  "score": 435.2283828040185,
+  "secondary": {
+    "allocBytesPerTx": 21545.28550480772,
+    "allocsPerTx": 272.5607043199206,
+    "nsPerTx": 47733.062170631965,
+    "cpuNsPerTx": 111112.12848163705,
+    "mutexWaitNsPerTx": 1249.0693412237033
+  },
+  "weights": {
+    "objRead": 57,
+    "objWrite": 70,
+    "metaRead": 31,
+    "metaWrite": 31,
+    "objList": 31
+  },
+  "workloads": [
+    {
+      "name": "singleRMW",
+      "txn": 200,
+      "objReads": 1,
+      "objWrites": 202,
+      "metaReads": 3,
+      "metaWrites": 4,
+      "objLists": 0,
+      "retries": 0,
+      "costPerTx": 72.07,
+      "allocBytesPerTx": 3275,
+      "allocsPerTx": 43.11,
+      "nsPerTx": 11604.37,
+      "cpuNsPerTx": 15845,
+      "mutexWaitNsPerTx": 0
+    },
+    {
+      "name": "multiRMW10",
+      "txn": 100,
+      "objReads": 10,
+      "objWrites": 1100,
+      "metaReads": 10,
+      "metaWrites": 991,
+      "objLists": 0,
+      "retries": 0,
+      "costPerTx": 1086.01,
+      "allocBytesPerTx": 55792.24,
+      "allocsPerTx": 748.03,
+      "nsPerTx": 156904.4,
+      "cpuNsPerTx": 463280,
+      "mutexWaitNsPerTx": 63020.56
+    },
+    {
+      "name": "batchRead10",
+      "txn": 200,
+      "objReads": 0,
+      "objWrites": 10,
+      "metaReads": 2000,
+      "metaWrites": 1,
+      "objLists": 0,
+      "retries": 0,
+      "costPerTx": 313.655,
+      "allocBytesPerTx": 16376.56,
+      "allocsPerTx": 181.325,
+      "nsPerTx": 47589.045,
+      "cpuNsPerTx": 110120,
+      "mutexWaitNsPerTx": 18260.12
+    },
+    {
+      "name": "batchWrite100",
+      "txn": 50,
+      "objReads": 0,
+      "objWrites": 9950,
+      "metaReads": 10000,
+      "metaWrites": 99,
+      "objLists": 0,
+      "retries": 0,
+      "costPerTx": 20191.38,
+      "allocBytesPerTx": 608433.76,
+      "allocsPerTx": 7615.56,
+      "nsPerTx": 974239,
+      "cpuNsPerTx": 4750800,
+      "mutexWaitNsPerTx": 2642085.44
+    },
+    {
+      "name": "readRepeat",
+      "txn": 200,
+      "objReads": 0,
+      "objWrites": 1,
+      "metaReads": 200,
+      "metaWrites": 1,
+      "objLists": 0,
+      "retries": 0,
+      "costPerTx": 31.505,
+      "allocBytesPerTx": 2550,
+      "allocsPerTx": 33.78,
+      "nsPerTx": 2935.4,
+      "cpuNsPerTx": 4410,
+      "mutexWaitNsPerTx": 0
+    }
+  ],
+  "scores": [
+    435.2283828040185,
+    434.85332095444363,
+    435.2532270312585
+  ]
+}

--- a/hack/autoresearch/best.json
+++ b/hack/autoresearch/best.json
@@ -1,0 +1,104 @@
+{
+  "score": 420.56100011554486,
+  "secondary": {
+    "allocBytesPerTx": 20151.043202775913,
+    "allocsPerTx": 255.9364832993143,
+    "nsPerTx": 30370.82384930864,
+    "cpuNsPerTx": 66745.24872548855,
+    "mutexWaitNsPerTx": 528.2364313103966
+  },
+  "weights": {
+    "objRead": 57,
+    "objWrite": 70,
+    "metaRead": 31,
+    "metaWrite": 31,
+    "objList": 31
+  },
+  "workloads": [
+    {
+      "name": "singleRMW",
+      "txn": 200,
+      "objReads": 1,
+      "objWrites": 202,
+      "metaReads": 2,
+      "metaWrites": 4,
+      "objLists": 0,
+      "retries": 0,
+      "costPerTx": 71.915,
+      "allocBytesPerTx": 2898.96,
+      "allocsPerTx": 40.16,
+      "nsPerTx": 3953.805,
+      "cpuNsPerTx": 4510,
+      "mutexWaitNsPerTx": 0
+    },
+    {
+      "name": "multiRMW10",
+      "txn": 100,
+      "objReads": 10,
+      "objWrites": 1100,
+      "metaReads": 0,
+      "metaWrites": 992,
+      "objLists": 0,
+      "retries": 0,
+      "costPerTx": 1083.22,
+      "allocBytesPerTx": 52521.36,
+      "allocsPerTx": 738.64,
+      "nsPerTx": 99797.4,
+      "cpuNsPerTx": 289500,
+      "mutexWaitNsPerTx": 7870.96
+    },
+    {
+      "name": "batchRead10",
+      "txn": 200,
+      "objReads": 0,
+      "objWrites": 10,
+      "metaReads": 2000,
+      "metaWrites": 1,
+      "objLists": 0,
+      "retries": 0,
+      "costPerTx": 313.655,
+      "allocBytesPerTx": 16295.28,
+      "allocsPerTx": 181.09,
+      "nsPerTx": 45052.99,
+      "cpuNsPerTx": 115135,
+      "mutexWaitNsPerTx": 2169.8
+    },
+    {
+      "name": "batchWrite100",
+      "txn": 50,
+      "objReads": 0,
+      "objWrites": 9950,
+      "metaReads": 5000,
+      "metaWrites": 99,
+      "objLists": 0,
+      "retries": 0,
+      "costPerTx": 17091.38,
+      "allocBytesPerTx": 605471.84,
+      "allocsPerTx": 7600.96,
+      "nsPerTx": 836690.72,
+      "cpuNsPerTx": 4394960,
+      "mutexWaitNsPerTx": 2408209.92
+    },
+    {
+      "name": "readRepeat",
+      "txn": 200,
+      "objReads": 0,
+      "objWrites": 1,
+      "metaReads": 200,
+      "metaWrites": 1,
+      "objLists": 0,
+      "retries": 0,
+      "costPerTx": 31.505,
+      "allocBytesPerTx": 2211.84,
+      "allocsPerTx": 26.895,
+      "nsPerTx": 1737.24,
+      "cpuNsPerTx": 2005,
+      "mutexWaitNsPerTx": 0
+    }
+  ],
+  "scores": [
+    419.94464270924055,
+    420.92295434337075,
+    420.56100011554486
+  ]
+}

--- a/internal/concurr/backoff.go
+++ b/internal/concurr/backoff.go
@@ -8,10 +8,10 @@ import (
 	"github.com/cenkalti/backoff/v4"
 )
 
-// TODO: Make these configurable. Compute them based on backend latency.
+// Default retry timing, used when a caller does not tune it explicitly.
 const (
-	initialInterval = 200 * time.Millisecond
-	maxInterval     = 5 * time.Second
+	defaultInitialInterval = 200 * time.Millisecond
+	defaultMaxInterval     = 5 * time.Second
 )
 
 // Permanent wraps an error to signal that retries should stop immediately.
@@ -25,32 +25,53 @@ func IsPermanent(err error) bool {
 	return errors.As(err, &perr)
 }
 
-// Retrier provides configurable exponential backoff retry logic.
+// RetryConfig configures the exponential backoff used by a Retrier.
+type RetryConfig struct {
+	// InitialInterval is the delay before the first retry; it grows
+	// exponentially up to MaxInterval.
+	InitialInterval time.Duration
+	// MaxInterval caps the per-retry delay.
+	MaxInterval time.Duration
+	// Jitter randomizes intervals to spread retries and avoid thundering-herd
+	// contention. Keep it enabled in production; disable it only where
+	// deterministic retry timing is required (e.g. tests), since it draws from
+	// the process-global math/rand that testing/synctest does not virtualize.
+	Jitter bool
+}
+
+// DefaultRetryConfig returns the production retry configuration.
+func DefaultRetryConfig() RetryConfig {
+	return RetryConfig{
+		InitialInterval: defaultInitialInterval,
+		MaxInterval:     defaultMaxInterval,
+		Jitter:          true,
+	}
+}
+
+// Retrier retries an operation with exponential backoff.
 type Retrier struct {
-	backoff.BackOff
+	cfg RetryConfig
 }
 
-// RetryOptions creates a Retrier with the given initial and maximum backoff intervals.
-func RetryOptions(initial, maxInterval time.Duration) Retrier {
-	b := backoff.NewExponentialBackOff()
-	b.InitialInterval = initial
-	b.MaxInterval = maxInterval
-	b.MaxElapsedTime = 0
-	// Disable interval randomization. Jitter would make retry timing depend on
-	// an uncontrolled global RNG, which makes the serializability fuzzer
-	// non-reproducible; progress under contention is guaranteed by the
-	// wound-wait rule and the serial-locking fallback, not by jitter.
-	b.RandomizationFactor = 0
-	return Retrier{b}
+// NewRetrier creates a Retrier from the given configuration.
+func NewRetrier(cfg RetryConfig) Retrier {
+	return Retrier{cfg: cfg}
 }
 
-// Retry calls fn repeatedly with exponential backoff until it succeeds or ctx is cancelled.
+// DefaultRetrier returns a Retrier using DefaultRetryConfig.
+func DefaultRetrier() Retrier {
+	return NewRetrier(DefaultRetryConfig())
+}
+
+// Retry calls fn repeatedly with exponential backoff until it succeeds, returns
+// a permanent error, or ctx is cancelled.
 func (r Retrier) Retry(ctx context.Context, fn func() error) error {
-	return backoff.Retry(fn, backoff.WithContext(r.BackOff, ctx))
-}
-
-// RetryWithBackoff retries f with default exponential backoff settings until it succeeds or ctx is cancelled.
-func RetryWithBackoff(ctx context.Context, f func() error) error {
-	r := RetryOptions(initialInterval, maxInterval)
-	return backoff.Retry(f, backoff.WithContext(r.BackOff, ctx))
+	b := backoff.NewExponentialBackOff()
+	b.InitialInterval = r.cfg.InitialInterval
+	b.MaxInterval = r.cfg.MaxInterval
+	b.MaxElapsedTime = 0
+	if !r.cfg.Jitter {
+		b.RandomizationFactor = 0
+	}
+	return backoff.Retry(fn, backoff.WithContext(b, ctx))
 }

--- a/internal/concurr/backoff.go
+++ b/internal/concurr/backoff.go
@@ -36,6 +36,11 @@ func RetryOptions(initial, maxInterval time.Duration) Retrier {
 	b.InitialInterval = initial
 	b.MaxInterval = maxInterval
 	b.MaxElapsedTime = 0
+	// Disable interval randomization. Jitter would make retry timing depend on
+	// an uncontrolled global RNG, which makes the serializability fuzzer
+	// non-reproducible; progress under contention is guaranteed by the
+	// wound-wait rule and the serial-locking fallback, not by jitter.
+	b.RandomizationFactor = 0
 	return Retrier{b}
 }
 

--- a/internal/concurr/backoff.go
+++ b/internal/concurr/backoff.go
@@ -2,10 +2,11 @@ package concurr
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
+	"fmt"
+	"io"
 	"time"
-
-	"github.com/cenkalti/backoff/v4"
 )
 
 // Default retry timing, used when a caller does not tune it explicitly.
@@ -14,16 +15,33 @@ const (
 	defaultMaxInterval     = 5 * time.Second
 )
 
+// Exponential growth and jitter parameters. These mirror the defaults of the
+// previously-vendored cenkalti/backoff library.
+const (
+	backoffMultiplier    = 1.5
+	backoffRandomization = 0.5
+)
+
 // Permanent wraps an error to signal that retries should stop immediately.
 func Permanent(err error) error {
-	return backoff.Permanent(err)
+	if err == nil {
+		return nil
+	}
+	return &permanentError{err: err}
 }
 
 // IsPermanent reports whether the error was marked as permanent.
 func IsPermanent(err error) bool {
-	var perr *backoff.PermanentError
+	var perr *permanentError
 	return errors.As(err, &perr)
 }
+
+type permanentError struct {
+	err error
+}
+
+func (e *permanentError) Error() string { return e.err.Error() }
+func (e *permanentError) Unwrap() error { return e.err }
 
 // RetryConfig configures the exponential backoff used by a Retrier.
 type RetryConfig struct {
@@ -32,19 +50,19 @@ type RetryConfig struct {
 	InitialInterval time.Duration
 	// MaxInterval caps the per-retry delay.
 	MaxInterval time.Duration
-	// Jitter randomizes intervals to spread retries and avoid thundering-herd
-	// contention. Keep it enabled in production; disable it only where
-	// deterministic retry timing is required (e.g. tests), since it draws from
-	// the process-global math/rand that testing/synctest does not virtualize.
-	Jitter bool
+	// Rand is the source of jitter randomness. Jitter randomizes each interval
+	// to spread retries and avoid thundering-herd contention. When Rand is nil
+	// no jitter is applied and intervals are purely exponential, which keeps
+	// retry timing deterministic. Rand must be safe for concurrent use.
+	Rand io.Reader
 }
 
-// DefaultRetryConfig returns the production retry configuration.
+// DefaultRetryConfig returns the default retry timing. Jitter is disabled
+// (Rand is nil); callers that want jitter must supply a randomness source.
 func DefaultRetryConfig() RetryConfig {
 	return RetryConfig{
 		InitialInterval: defaultInitialInterval,
 		MaxInterval:     defaultMaxInterval,
-		Jitter:          true,
 	}
 }
 
@@ -53,8 +71,15 @@ type Retrier struct {
 	cfg RetryConfig
 }
 
-// NewRetrier creates a Retrier from the given configuration.
+// NewRetrier creates a Retrier from the given configuration, filling unset
+// (non-positive) intervals with defaults.
 func NewRetrier(cfg RetryConfig) Retrier {
+	if cfg.InitialInterval <= 0 {
+		cfg.InitialInterval = defaultInitialInterval
+	}
+	if cfg.MaxInterval <= 0 {
+		cfg.MaxInterval = defaultMaxInterval
+	}
 	return Retrier{cfg: cfg}
 }
 
@@ -64,14 +89,57 @@ func DefaultRetrier() Retrier {
 }
 
 // Retry calls fn repeatedly with exponential backoff until it succeeds, returns
-// a permanent error, or ctx is cancelled.
+// a permanent error (see Permanent), or ctx is cancelled. It does not give up
+// on its own: it retries indefinitely until one of those conditions is met.
 func (r Retrier) Retry(ctx context.Context, fn func() error) error {
-	b := backoff.NewExponentialBackOff()
-	b.InitialInterval = r.cfg.InitialInterval
-	b.MaxInterval = r.cfg.MaxInterval
-	b.MaxElapsedTime = 0
-	if !r.cfg.Jitter {
-		b.RandomizationFactor = 0
+	interval := r.cfg.InitialInterval
+	for {
+		err := fn()
+		if err == nil {
+			return nil
+		}
+		if perr, ok := errors.AsType[*permanentError](err); ok {
+			return perr.err
+		}
+
+		wait := r.jittered(interval)
+		interval = nextInterval(interval, r.cfg.MaxInterval)
+
+		timer := time.NewTimer(wait)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
 	}
-	return backoff.Retry(fn, backoff.WithContext(b, ctx))
+}
+
+// jittered randomizes interval within [interval*(1-f), interval*(1+f)] when a
+// jitter source is configured, or returns it unchanged otherwise.
+func (r Retrier) jittered(interval time.Duration) time.Duration {
+	if r.cfg.Rand == nil {
+		return interval
+	}
+	delta := backoffRandomization * float64(interval)
+	lo := float64(interval) - delta
+	hi := float64(interval) + delta
+	return time.Duration(lo + readFloat(r.cfg.Rand)*(hi-lo+1))
+}
+
+// nextInterval grows current by the multiplier, capped at maxInterval.
+func nextInterval(current, maxInterval time.Duration) time.Duration {
+	if float64(current) >= float64(maxInterval)/backoffMultiplier {
+		return maxInterval
+	}
+	return time.Duration(float64(current) * backoffMultiplier)
+}
+
+// readFloat draws a float64 in [0,1) from r, mirroring math/rand's Float64.
+func readFloat(r io.Reader) float64 {
+	var b [8]byte
+	if _, err := io.ReadFull(r, b[:]); err != nil {
+		panic(fmt.Sprintf("cannot read from jitter random source: %v", err))
+	}
+	return float64(binary.BigEndian.Uint64(b[:])>>11) / (1 << 53)
 }

--- a/internal/data/txid.go
+++ b/internal/data/txid.go
@@ -54,9 +54,15 @@ func (t TxID) priority() uint64 {
 	return binary.BigEndian.Uint64(t[txIDTSOff:])
 }
 
-// NewTId generates a new transaction ID using the current time as its priority.
-func NewTId() TxID {
-	return newTID(time.Now())
+// Time returns the priority timestamp encoded in the ID. RenewTID preserves it,
+// so a wounded transaction keeps the same Time across restarts.
+func (t TxID) Time() time.Time {
+	return time.Unix(0, int64(t.priority()))
+}
+
+// NewTID generates a new transaction ID using the current time as its priority.
+func NewTID() TxID {
+	return defaultTxIDSource.New()
 }
 
 // RenewTID returns a transaction ID that preserves the priority (timestamp) of
@@ -64,10 +70,7 @@ func NewTId() TxID {
 // on restart to avoid starvation, while the new prefix gives it a distinct log
 // object that lands in a different storage partition.
 func RenewTID(old TxID) TxID {
-	res := make([]byte, txIDLen)
-	randPrefix(res)
-	copy(res[txIDTSOff:], old[txIDTSOff:])
-	return res
+	return defaultTxIDSource.Renew(old)
 }
 
 // TIDWithPriority builds a transaction ID from an explicit timestamp and random
@@ -79,43 +82,43 @@ func TIDWithPriority(ts time.Time, prefix []byte) TxID {
 	return res
 }
 
-// NewTIDFromSource generates a transaction ID using ts as its priority and src
-// as the source of the random prefix. It lets deterministic tests (e.g. the
-// serializability fuzzer) control the otherwise-random prefix so that a given
-// input reproduces exactly; production code uses NewTId (crypto/rand).
-func NewTIDFromSource(src io.Reader, ts time.Time) TxID {
-	res := make([]byte, txIDLen)
-	prefixFromSource(src, res)
-	binary.BigEndian.PutUint64(res[txIDTSOff:], uint64(ts.UnixNano()))
-	return res
+// defaultTxIDSource backs NewTId and RenewTID, drawing prefixes from crypto/rand.
+var defaultTxIDSource = NewTxIDSource(nil)
+
+// TxIDSource mints transaction IDs, drawing the random prefix from rand (nil
+// means crypto/rand). Deterministic tests pass a seeded reader so transaction
+// IDs reproduce exactly; the priority (timestamp) still comes from the clock.
+type TxIDSource struct {
+	rand io.Reader
 }
 
-// RenewTIDFromSource behaves like RenewTID but draws the fresh prefix from src,
-// keeping wounded-transaction restarts deterministic under a fixed source.
-func RenewTIDFromSource(src io.Reader, old TxID) TxID {
-	res := make([]byte, txIDLen)
-	prefixFromSource(src, res)
-	copy(res[txIDTSOff:], old[txIDTSOff:])
-	return res
-}
-
-func newTID(ts time.Time) TxID {
-	res := make([]byte, txIDLen)
-	randPrefix(res)
-	binary.BigEndian.PutUint64(res[txIDTSOff:], uint64(ts.UnixNano()))
-	return res
-}
-
-func randPrefix(b []byte) {
-	if _, err := rand.Read(b[:txIDTSOff]); err != nil {
-		panic(fmt.Sprintf("Cannot read from random device: %v", err))
+// NewTxIDSource returns a TxIDSource that draws prefixes from r, defaulting to
+// crypto/rand when r is nil. r must be safe for concurrent use.
+func NewTxIDSource(r io.Reader) TxIDSource {
+	if r == nil {
+		r = rand.Reader
 	}
+	return TxIDSource{rand: r}
 }
 
-func prefixFromSource(src io.Reader, b []byte) {
-	if _, err := io.ReadFull(src, b[:txIDTSOff]); err != nil {
+// New returns a fresh transaction ID using the current time as its priority.
+func (s TxIDSource) New() TxID {
+	return s.tid(time.Now())
+}
+
+// Renew returns a transaction ID with a fresh prefix that preserves old's
+// priority (timestamp), mirroring a wounded transaction's restart.
+func (s TxIDSource) Renew(old TxID) TxID {
+	return s.tid(old.Time())
+}
+
+func (s TxIDSource) tid(ts time.Time) TxID {
+	res := make([]byte, txIDLen)
+	if _, err := io.ReadFull(s.rand, res[:txIDTSOff]); err != nil {
 		panic(fmt.Sprintf("Cannot read from random source: %v", err))
 	}
+	binary.BigEndian.PutUint64(res[txIDTSOff:], uint64(ts.UnixNano()))
+	return res
 }
 
 // NewTxIDSet creates a TxIDSet containing the given transaction IDs, deduplicating any repeats.

--- a/internal/data/txid.go
+++ b/internal/data/txid.go
@@ -8,6 +8,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"time"
 )
 
@@ -78,6 +79,26 @@ func TIDWithPriority(ts time.Time, prefix []byte) TxID {
 	return res
 }
 
+// NewTIDFromSource generates a transaction ID using ts as its priority and src
+// as the source of the random prefix. It lets deterministic tests (e.g. the
+// serializability fuzzer) control the otherwise-random prefix so that a given
+// input reproduces exactly; production code uses NewTId (crypto/rand).
+func NewTIDFromSource(src io.Reader, ts time.Time) TxID {
+	res := make([]byte, txIDLen)
+	prefixFromSource(src, res)
+	binary.BigEndian.PutUint64(res[txIDTSOff:], uint64(ts.UnixNano()))
+	return res
+}
+
+// RenewTIDFromSource behaves like RenewTID but draws the fresh prefix from src,
+// keeping wounded-transaction restarts deterministic under a fixed source.
+func RenewTIDFromSource(src io.Reader, old TxID) TxID {
+	res := make([]byte, txIDLen)
+	prefixFromSource(src, res)
+	copy(res[txIDTSOff:], old[txIDTSOff:])
+	return res
+}
+
 func newTID(ts time.Time) TxID {
 	res := make([]byte, txIDLen)
 	randPrefix(res)
@@ -88,6 +109,12 @@ func newTID(ts time.Time) TxID {
 func randPrefix(b []byte) {
 	if _, err := rand.Read(b[:txIDTSOff]); err != nil {
 		panic(fmt.Sprintf("Cannot read from random device: %v", err))
+	}
+}
+
+func prefixFromSource(src io.Reader, b []byte) {
+	if _, err := io.ReadFull(src, b[:txIDTSOff]); err != nil {
+		panic(fmt.Sprintf("Cannot read from random source: %v", err))
 	}
 }
 

--- a/internal/data/txid_test.go
+++ b/internal/data/txid_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestNewTIdLayout(t *testing.T) {
-	id := NewTId()
+	id := NewTID()
 	assert.Len(t, []byte(id), txIDLen)
 	// The timestamp suffix should decode to something close to now.
 	got := time.Unix(0, int64(id.priority()))
@@ -61,7 +61,7 @@ func TestRenewTIDDoesNotFlipOrdering(t *testing.T) {
 }
 
 func TestRenewTIDPreservesPriority(t *testing.T) {
-	orig := NewTId()
+	orig := NewTID()
 	renewed := RenewTID(orig)
 
 	require.Len(t, []byte(renewed), txIDLen)
@@ -76,7 +76,7 @@ func TestRenewTIDPreservesPriority(t *testing.T) {
 func TestNewTIdUnique(t *testing.T) {
 	seen := make(map[string]struct{})
 	for range 1000 {
-		id := NewTId()
+		id := NewTID()
 		_, ok := seen[string(id)]
 		require.False(t, ok, "duplicate TxID generated")
 		seen[string(id)] = struct{}{}

--- a/internal/trans/algo.go
+++ b/internal/trans/algo.go
@@ -5,6 +5,7 @@ package trans
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"sort"
 	"time"
@@ -214,8 +215,8 @@ func (t Algo) Reset(tx *Handle, data Data) {
 // the original priority (timestamp) so it is not starved, but with a new ID so
 // it gets a distinct transaction log. The locks of the old attempt are not
 // carried over; callers should release them separately.
-func (t Algo) Rebegin(_ context.Context, old *Handle, d Data) *Handle {
-	tid := data.RenewTID(old.id)
+func (t Algo) Rebegin(ctx context.Context, old *Handle, d Data) *Handle {
+	tid := renewTID(ctx, old.id)
 	return &Handle{
 		id:     tid,
 		data:   d,
@@ -469,12 +470,20 @@ func (t Algo) validateLockedRead(
 	// Let's update our local copy and retry.
 	item.Result = vResultRetry
 
-	if expectedVal.Status == storage.TxCommitStatusUnknown {
+	if expectedVal.Status != storage.TxCommitStatusOK {
 		// Fetch the expected committed value.
 		expectedVal, err = t.mon.CommittedValue(ctx, item.Path, expectedWriter)
-		if err != nil || expectedVal.Value.NotWritten {
-			// No need to report an error here.
-			// We just can't update the local cache.
+		if err != nil || expectedVal.Status != storage.TxCommitStatusOK || expectedVal.Value.NotWritten {
+			// We cannot authoritatively resolve expectedWriter's value. This
+			// happens when expectedWriter committed through the single-RW fast
+			// path, which writes no transaction log, so its log-based status is
+			// unknown/aborted even though it did commit. Caching a guessed value
+			// here would be corrupting: it would pair value bytes with a writer
+			// that did not produce them, and a later read could trust that
+			// (writer matches the live last-writer) and overwrite a newer value,
+			// losing an update. Instead, invalidate the stale cached value so the
+			// retry re-reads the authoritative one straight from storage.
+			t.local.MarkValueOutated(item.Path, item.ReadVersion)
 			return nil
 		}
 	}
@@ -553,13 +562,19 @@ func (t Algo) validateReadNotFound(ctx context.Context, item *pathState) error {
 		return nil
 	}
 
-	// Was written to. Update local cache and retry.
-	t.updateLocal(
-		WriteAccess{
-			Path:   item.Path,
-			Val:    v.Value.Value,
-			Delete: v.Value.Deleted},
-		lastWriter)
+	// Was written to: retry. Only refresh the local cache when we could
+	// authoritatively resolve the value. If lastWriter committed via the
+	// single-RW fast path it has no transaction log, so the value is
+	// unresolvable here; caching a guessed value would corrupt the entry, so we
+	// just retry and let the next read fetch the authoritative value.
+	if v.Status == storage.TxCommitStatusOK && !v.Value.NotWritten {
+		t.updateLocal(
+			WriteAccess{
+				Path:   item.Path,
+				Val:    v.Value.Value,
+				Delete: v.Value.Deleted},
+			lastWriter)
+	}
 
 	item.Result = vResultRetry
 	return nil
@@ -1126,7 +1141,14 @@ type Handle struct {
 	log           *slog.Logger
 }
 
-var txIDKey = struct{}{}
+// ctxKey is a private type for context keys defined in this package, so that
+// distinct keys never collide with each other or with keys from other packages.
+type ctxKey int
+
+const (
+	txIDKey ctxKey = iota
+	idSourceKey
+)
 
 // CtxWithTxID returns a new context carrying the given transaction ID.
 func CtxWithTxID(ctx context.Context, id data.TxID) context.Context {
@@ -1244,6 +1266,13 @@ func initValidation(h *Handle) *validationState {
 	for _, v := range m {
 		res = append(res, v)
 	}
+	// Iterate in a stable path order so the sequence of backend operations a
+	// transaction issues does not depend on Go's randomized map iteration. This
+	// keeps the parallel validation path deterministic (the serial path already
+	// sorts), which is what makes the serializability fuzzer reproducible.
+	sort.Slice(res, func(i, j int) bool {
+		return res[i].Path < res[j].Path
+	})
 	return &validationState{
 		Paths: res,
 	}
@@ -1339,6 +1368,11 @@ func collectionsLocks(vstate *validationState) ([]storage.PathLock, error) {
 			Type: t,
 		})
 	}
+	// Stable order: the collection-lock acquisition sequence must not depend on
+	// map iteration order (see initValidation).
+	sort.Slice(res, func(i, j int) bool {
+		return res[i].Path < res[j].Path
+	})
 	return res, nil
 }
 
@@ -1370,5 +1404,32 @@ func newTxID(ctx context.Context) data.TxID {
 	if id := TxIDFromCtx(ctx); id != nil {
 		return id
 	}
+	if src := idSourceFromCtx(ctx); src != nil {
+		return data.NewTIDFromSource(src, time.Now())
+	}
 	return data.NewTId()
+}
+
+func renewTID(ctx context.Context, old data.TxID) data.TxID {
+	if src := idSourceFromCtx(ctx); src != nil {
+		return data.RenewTIDFromSource(src, old)
+	}
+	return data.RenewTID(old)
+}
+
+// CtxWithIDSource returns a context that makes transactions begun (or wounded
+// and restarted) under it draw their ID random prefix from src instead of
+// crypto/rand. The transaction priority still comes from the clock, so this
+// does not change wound-wait ordering; it only removes the prefix as a source
+// of nondeterminism. Intended for deterministic tests; src should be safe for
+// concurrent use.
+func CtxWithIDSource(ctx context.Context, src io.Reader) context.Context {
+	return context.WithValue(ctx, idSourceKey, src)
+}
+
+func idSourceFromCtx(ctx context.Context) io.Reader {
+	if src, ok := ctx.Value(idSourceKey).(io.Reader); ok {
+		return src
+	}
+	return nil
 }

--- a/internal/trans/algo.go
+++ b/internal/trans/algo.go
@@ -5,7 +5,6 @@ package trans
 import (
 	"context"
 	"fmt"
-	"io"
 	"log/slog"
 	"sort"
 	"time"
@@ -71,6 +70,7 @@ func NewAlgo(
 	gc *GC,
 	bg *concurr.Background,
 	log *slog.Logger,
+	txIDs data.TxIDSource,
 ) Algo {
 	return Algo{
 		global:     g,
@@ -81,6 +81,7 @@ func NewAlgo(
 		gc:         gc,
 		background: bg,
 		log:        log,
+		txIDs:      txIDs,
 	}
 }
 
@@ -95,11 +96,17 @@ type Algo struct {
 	gc         *GC
 	background *concurr.Background
 	log        *slog.Logger
+	txIDs      data.TxIDSource
 }
 
 // Begin starts a new transaction with the given data and returns a handle to it.
 func (t Algo) Begin(ctx context.Context, d Data) *Handle {
-	tid := newTxID(ctx)
+	// CtxWithTxID lets tests pin a specific ID (and thus priority); otherwise
+	// the ID comes from the configured source.
+	tid := TxIDFromCtx(ctx)
+	if tid == nil {
+		tid = t.txIDs.New()
+	}
 	return &Handle{
 		id:     tid,
 		data:   d,
@@ -215,8 +222,8 @@ func (t Algo) Reset(tx *Handle, data Data) {
 // the original priority (timestamp) so it is not starved, but with a new ID so
 // it gets a distinct transaction log. The locks of the old attempt are not
 // carried over; callers should release them separately.
-func (t Algo) Rebegin(ctx context.Context, old *Handle, d Data) *Handle {
-	tid := renewTID(ctx, old.id)
+func (t Algo) Rebegin(_ context.Context, old *Handle, d Data) *Handle {
+	tid := t.txIDs.Renew(old.id)
 	return &Handle{
 		id:     tid,
 		data:   d,
@@ -1145,12 +1152,11 @@ type Handle struct {
 // distinct keys never collide with each other or with keys from other packages.
 type ctxKey int
 
-const (
-	txIDKey ctxKey = iota
-	idSourceKey
-)
+const txIDKey ctxKey = iota
 
-// CtxWithTxID returns a new context carrying the given transaction ID.
+// CtxWithTxID returns a new context carrying the given transaction ID. It lets
+// tests pin a transaction's ID (and thus its wound-wait priority); production
+// leaves it unset and the ID comes from the Algo's configured TxID source.
 func CtxWithTxID(ctx context.Context, id data.TxID) context.Context {
 	return context.WithValue(ctx, txIDKey, id)
 }
@@ -1397,39 +1403,4 @@ type txLog data.TxID
 
 func (t txLog) LogValue() slog.Value {
 	return slog.StringValue(data.TxID(t).String())
-}
-
-func newTxID(ctx context.Context) data.TxID {
-	// Allow for deterministic transaction IDs (only in tests).
-	if id := TxIDFromCtx(ctx); id != nil {
-		return id
-	}
-	if src := idSourceFromCtx(ctx); src != nil {
-		return data.NewTIDFromSource(src, time.Now())
-	}
-	return data.NewTId()
-}
-
-func renewTID(ctx context.Context, old data.TxID) data.TxID {
-	if src := idSourceFromCtx(ctx); src != nil {
-		return data.RenewTIDFromSource(src, old)
-	}
-	return data.RenewTID(old)
-}
-
-// CtxWithIDSource returns a context that makes transactions begun (or wounded
-// and restarted) under it draw their ID random prefix from src instead of
-// crypto/rand. The transaction priority still comes from the clock, so this
-// does not change wound-wait ordering; it only removes the prefix as a source
-// of nondeterminism. Intended for deterministic tests; src should be safe for
-// concurrent use.
-func CtxWithIDSource(ctx context.Context, src io.Reader) context.Context {
-	return context.WithValue(ctx, idSourceKey, src)
-}
-
-func idSourceFromCtx(ctx context.Context) io.Reader {
-	if src, ok := ctx.Value(idSourceKey).(io.Reader); ok {
-		return src
-	}
-	return nil
 }

--- a/internal/trans/algo_fuzz_test.go
+++ b/internal/trans/algo_fuzz_test.go
@@ -3,7 +3,10 @@ package trans
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
+	"math/rand"
+	"sync"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -17,6 +20,7 @@ import (
 	"github.com/mbrt/glassdb/backend/middleware"
 	"github.com/mbrt/glassdb/internal/cache"
 	"github.com/mbrt/glassdb/internal/concurr"
+	"github.com/mbrt/glassdb/internal/data"
 	"github.com/mbrt/glassdb/internal/data/paths"
 	"github.com/mbrt/glassdb/internal/errors"
 	"github.com/mbrt/glassdb/internal/storage"
@@ -50,7 +54,25 @@ type fuzzAlgoEnv struct {
 	tctx   testContext
 }
 
-func newFuzzAlgoEnv(t testing.TB, b backend.Backend) fuzzAlgoEnv {
+// newDetReader returns a deterministic, concurrency-safe source of random bytes
+// used as an Algo's transaction-ID prefix source so a given schedule reproduces
+// exactly under a fixed seed.
+func newDetReader(seed int64) io.Reader {
+	return &lockedRand{r: rand.New(rand.NewSource(seed))}
+}
+
+type lockedRand struct {
+	mu sync.Mutex
+	r  *rand.Rand
+}
+
+func (l *lockedRand) Read(p []byte) (int, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.r.Read(p)
+}
+
+func newFuzzAlgoEnv(t testing.TB, b backend.Backend, src data.TxIDSource) fuzzAlgoEnv {
 	t.Helper()
 
 	log := slog.New(nilHandler{})
@@ -60,11 +82,15 @@ func newFuzzAlgoEnv(t testing.TB, b backend.Backend) fuzzAlgoEnv {
 	tlogger := storage.NewTLogger(global, local, testCollName)
 	background := concurr.NewBackground()
 	t.Cleanup(background.Close)
-	tmon := NewMonitor(local, tlogger, background)
+	// Disable backoff jitter so retry timing is deterministic and the fuzzer
+	// stays reproducible (jitter draws from the un-virtualized global RNG).
+	rcfg := concurr.DefaultRetryConfig()
+	rcfg.Jitter = false
+	tmon := NewMonitor(local, tlogger, background, concurr.NewRetrier(rcfg))
 	locker := NewLocker(local, global, tlogger, tmon)
 	gc := NewGC(background, tlogger, log)
 
-	tm := NewAlgo(global, local, locker, tmon, gc, nil, log)
+	tm := NewAlgo(global, local, locker, tmon, gc, nil, log, src)
 	return fuzzAlgoEnv{
 		algo:   tm,
 		reader: NewReader(local, global, tmon),
@@ -106,8 +132,10 @@ func fuzzAlgoConcurrentTx(t *testing.T, schedule []byte) {
 	sched := middleware.NewScheduler(schedule, time.Millisecond)
 	b := middleware.NewScheduledBackend(memory.New(), sched)
 
-	env1 := newFuzzAlgoEnv(t, b)
-	env2 := newFuzzAlgoEnv(t, b)
+	// Distinct seeds keep the two clients' transaction IDs disjoint and
+	// reproducible under a fixed schedule.
+	env1 := newFuzzAlgoEnv(t, b, data.NewTxIDSource(newDetReader(1)))
+	env2 := newFuzzAlgoEnv(t, b, data.NewTxIDSource(newDetReader(2)))
 
 	keys := []string{
 		paths.FromKey(testCollName, []byte("k1")),

--- a/internal/trans/algo_fuzz_test.go
+++ b/internal/trans/algo_fuzz_test.go
@@ -82,11 +82,9 @@ func newFuzzAlgoEnv(t testing.TB, b backend.Backend, src data.TxIDSource) fuzzAl
 	tlogger := storage.NewTLogger(global, local, testCollName)
 	background := concurr.NewBackground()
 	t.Cleanup(background.Close)
-	// Disable backoff jitter so retry timing is deterministic and the fuzzer
-	// stays reproducible (jitter draws from the un-virtualized global RNG).
-	rcfg := concurr.DefaultRetryConfig()
-	rcfg.Jitter = false
-	tmon := NewMonitor(local, tlogger, background, concurr.NewRetrier(rcfg))
+	// DefaultRetrier applies no jitter (its Rand source is nil), so retry
+	// timing is purely exponential and the fuzzer stays reproducible.
+	tmon := NewMonitor(local, tlogger, background, concurr.DefaultRetrier())
 	locker := NewLocker(local, global, tlogger, tmon)
 	gc := NewGC(background, tlogger, log)
 

--- a/internal/trans/algo_test.go
+++ b/internal/trans/algo_test.go
@@ -65,7 +65,7 @@ func newAlgoFromBackend(t *testing.T, b backend.Backend) (Algo, testContext) {
 	tlogger := storage.NewTLogger(global, local, testCollName)
 	background := concurr.NewBackground()
 	t.Cleanup(background.Close)
-	tmon := NewMonitor(local, tlogger, background)
+	tmon := NewMonitor(local, tlogger, background, concurr.DefaultRetrier())
 	locker := NewLocker(local, global, tlogger, tmon)
 	gc := NewGC(background, tlogger, log)
 
@@ -77,7 +77,7 @@ func newAlgoFromBackend(t *testing.T, b backend.Backend) (Algo, testContext) {
 	_, err := global.Write(ctx, paths.CollectionInfo(testCollName), collInfoContents, nil)
 	require.NoError(t, err)
 
-	tm := NewAlgo(global, local, locker, tmon, gc, background, log)
+	tm := NewAlgo(global, local, locker, tmon, gc, background, log, data.NewTxIDSource(nil))
 	return tm, testContext{
 		backend: b,
 		global:  global,
@@ -745,7 +745,7 @@ func TestCleanAbort(t *testing.T) {
 				assert.NoError(t, err)
 
 				// The keys should be lockable now.
-				txtest := data.NewTId()
+				txtest := data.NewTID()
 				tctx.tmon.BeginTx(ctx, txtest)
 				for _, key := range keys {
 					err := tctx.locker.LockWrite(ctx, key, txtest)
@@ -826,7 +826,7 @@ func TestChangeWritesCleanAbort(t *testing.T) {
 		assert.NoError(t, err)
 
 		// The keys should be lockable now.
-		txtest := data.NewTId()
+		txtest := data.NewTID()
 		tctx.tmon.BeginTx(ctx, txtest)
 		for _, key := range keys {
 			err := tctx.locker.LockWrite(ctx, key, txtest)

--- a/internal/trans/algo_test.go
+++ b/internal/trans/algo_test.go
@@ -906,6 +906,105 @@ func TestSingleRWRetry(t *testing.T) {
 	})
 }
 
+// TestSingleRWLostUpdate is the deterministic regression test for ADR-007.
+//
+// A writer that commits through the single read-modify-write fast path
+// (commitSingleRW) writes no transaction log, so its committed value cannot be
+// resolved from the log afterwards. The bug: when another transaction validated
+// a stale read against such a writer, validateLockedRead cached the unresolved
+// (empty) value tagged with that writer's ID. The local cache then served value
+// bytes that disagreed with their writer tag, and a later read-modify-write
+// based on those bytes silently overwrote the committed value: a lost update.
+//
+// This test recreates that exact situation and asserts that, after validation,
+// a read returns the authoritative value v1 (with writer W1) rather than the
+// stale guess. Before the fix it returns an empty value, reproducing the bug.
+func TestSingleRWLostUpdate(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := context.Background()
+		// Three independent clients sharing one backend, each with its own local
+		// cache: a writer, the victim, and a third client whose pending lock
+		// puts the key into the state that triggers the bug.
+		tmWriter, tctxW := testAlgoContext(t)
+		tmVictim, tctxV := newAlgoFromBackend(t, tctxW.backend)
+		_, tctxL := newAlgoFromBackend(t, tctxW.backend)
+		key := paths.FromKey("testp", []byte("k"))
+		v0 := []byte("v0")
+		v1 := []byte("v1")
+
+		// 1. Create k=v0 through a normal (logged) commit and flush it, so its
+		//    writer W0 is fully resolvable.
+		h0 := commitWrites(t, tmWriter, []WriteAccess{{Path: key, Val: v0}})
+		flushWrites(t, tmWriter, h0)
+
+		// 2. The victim reads k, caching v0@W0 in its local storage.
+		ra0, err := doRead(ctx, tctxV, key)
+		require.NoError(t, err)
+		require.True(t, ra0.Found)
+
+		// 3. The writer overwrites k=v1 through the single-RW fast path, which
+		//    writes no transaction log. The victim's cached read is now stale.
+		raW, err := doRead(ctx, tctxW, key)
+		require.NoError(t, err)
+		hW1 := commitAccess(t, tmWriter, Data{
+			Reads:  []ReadAccess{raW},
+			Writes: []WriteAccess{{Path: key, Val: v1}},
+		})
+		w1 := hW1.id
+		// The single-RW writer left no log: its status is unresolvable.
+		st, err := tctxW.tlogger.CommitStatus(ctx, w1)
+		require.NoError(t, err)
+		require.Equal(t, storage.TxCommitStatusUnknown, st.Status)
+		// Storage authoritatively holds v1, written by W1. Read it through the
+		// writer's client so the victim's stale cache is left untouched.
+		gr, err := tctxW.global.Read(ctx, key)
+		require.NoError(t, err)
+		require.Equal(t, v1, gr.Value)
+		require.True(t, w1.Equal(gr.Version.Writer))
+
+		// 4. A third client write-locks k and stays pending, so the victim
+		//    observes k locked in write while its last writer is the logless
+		//    single-RW writer. This drives validation into the unresolvable
+		//    branch (a committed locker would instead resolve the value). The
+		//    lock is taken from a separate client so the victim's cached read
+		//    stays stale (locking refreshes the locking client's own cache).
+		w2 := mkTID(5, "w2")
+		tctxL.tmon.BeginTx(ctx, w2)
+		require.NoError(t, tctxL.locker.LockWrite(ctx, key, w2))
+		info := lockInfo(ctx, t, tctxL, key)
+		require.Equal(t, storage.LockTypeWrite, info.Type)
+		require.Len(t, info.LockedBy, 1)
+		require.True(t, w2.Equal(info.LockedBy[0]))
+		require.True(t, w1.Equal(info.LastWriter))
+
+		// 5. The victim validates its now-stale read of k. Validation finds the
+		//    expected writer is the logless single-RW writer W1, which it cannot
+		//    resolve. The fix invalidates the stale cache entry instead of
+		//    caching a guessed value.
+		hv := tmVictim.Begin(ctx, Data{Reads: []ReadAccess{ra0}})
+		err = tmVictim.Commit(ctx, hv)
+		require.ErrorIs(t, err, ErrRetry)
+		require.NoError(t, tmVictim.End(ctx, hv))
+
+		// 6. The third client releases its lock; k is unlocked at v1@W1.
+		require.NoError(t, tctxL.locker.Unlock(ctx, key, w2))
+		info = lockInfo(ctx, t, tctxL, key)
+		require.Equal(t, storage.LockTypeNone, info.Type)
+		require.True(t, w1.Equal(info.LastWriter))
+		require.NoError(t, tctxL.tmon.AbortTx(ctx, w2))
+
+		// 7. Reading k must now return the authoritative committed value v1.
+		//    Before the fix, validation had cached an unresolved empty value
+		//    tagged with W1, so the reader served stale bytes whose contents
+		//    disagreed with the writer tag — the lost update.
+		reader := NewReader(tctxV.local, tctxV.global, tctxV.tmon)
+		rv, err := reader.Read(ctx, key, storage.MaxStaleness)
+		require.NoError(t, err)
+		assert.Equal(t, v1, rv.Value)
+		assert.True(t, w1.Equal(rv.Version.Writer))
+	})
+}
+
 func TestExpiredTx(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		ctx := context.Background()

--- a/internal/trans/monitor.go
+++ b/internal/trans/monitor.go
@@ -33,16 +33,19 @@ const (
 )
 
 // NewMonitor returns a Monitor that tracks local and remote transaction state
-// using the given transaction logger and background executor.
+// using the given transaction logger, background executor, and retrier (used
+// when polling remote transaction state and writing the final log).
 func NewMonitor(
 	l storage.Local,
 	tl storage.TLogger,
 	b *concurr.Background,
+	r concurr.Retrier,
 ) *Monitor {
 	return &Monitor{
 		local:      l,
 		tl:         tl,
 		background: b,
+		retrier:    r,
 		shards: shard.New(func(int) *monitorShard {
 			return &monitorShard{
 				localTx:   make(map[string]txStatus),
@@ -59,6 +62,7 @@ type Monitor struct {
 	local      storage.Local
 	tl         storage.TLogger
 	background *concurr.Background
+	retrier    concurr.Retrier
 	shards     shard.Sharded[monitorShard]
 }
 
@@ -434,7 +438,7 @@ func (m *Monitor) tryAbortRemoteTx(
 func (m *Monitor) pollTxStatus(ctx context.Context, tid data.TxID) (storage.TxCommitStatus, error) {
 	res := storage.TxCommitStatusUnknown
 
-	err := concurr.RetryWithBackoff(ctx, func() error {
+	err := m.retrier.Retry(ctx, func() error {
 		s, err := m.fetchRemoteTxStatus(ctx, tid)
 		if err != nil {
 			return concurr.Permanent(fmt.Errorf("in get commit status: %w", err))
@@ -505,7 +509,7 @@ func (m *Monitor) setFinalLog(ctx context.Context, tlog storage.TxLog) error {
 	sh.mu.Unlock()
 
 	// TODO: Add timeout ~= refreshTimeout here.
-	err := concurr.RetryWithBackoff(ctx, func() error {
+	err := m.retrier.Retry(ctx, func() error {
 		var err error
 		if lastV.IsNull() {
 			_, err = m.tl.Set(ctx, tlog)

--- a/internal/trans/monitor_test.go
+++ b/internal/trans/monitor_test.go
@@ -37,7 +37,7 @@ func newTestMonitor(t *testing.T, b backend.Backend) (*Monitor, monTestCtx) {
 	tl := storage.NewTLogger(g, l, "test")
 	bg := concurr.NewBackground()
 	t.Cleanup(bg.Close)
-	mon := NewMonitor(l, tl, bg)
+	mon := NewMonitor(l, tl, bg, concurr.DefaultRetrier())
 
 	return mon, monTestCtx{
 		Local:   l,

--- a/internal/trans/tlocker.go
+++ b/internal/trans/tlocker.go
@@ -3,6 +3,7 @@ package trans
 import (
 	"context"
 	"fmt"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -132,6 +133,11 @@ func (v *Locker) LockedPaths(tid data.TxID) []storage.PathLock {
 			Type: tp,
 		})
 	}
+	// Stable order so unlock/cleanup and tx-log lock lists do not depend on Go's
+	// randomized map iteration, keeping the serializability fuzzer reproducible.
+	sort.Slice(res, func(i, j int) bool {
+		return res[i].Path < res[j].Path
+	})
 	return res
 }
 

--- a/internal/trans/tlocker_test.go
+++ b/internal/trans/tlocker_test.go
@@ -43,7 +43,7 @@ func newTestLocker(t *testing.T, b backend.Backend) (*Locker, tlTestCtx) {
 	tl := storage.NewTLogger(g, l, "test")
 	bg := concurr.NewBackground()
 	t.Cleanup(bg.Close)
-	mon := NewMonitor(l, tl, bg)
+	mon := NewMonitor(l, tl, bg, concurr.DefaultRetrier())
 	locker := NewLocker(l, g, tl, mon)
 
 	return locker, tlTestCtx{
@@ -60,7 +60,7 @@ func TestLockCreate(t *testing.T) {
 		ctx := context.Background()
 		locker, tctx := initTLTest(t)
 		key := paths.FromKey("example", []byte("key"))
-		tx := data.NewTId()
+		tx := data.NewTID()
 		tctx.Monitor.BeginTx(ctx, tx)
 
 		// Lock unlock without commit.
@@ -107,7 +107,7 @@ func TestLockCreateFail(t *testing.T) {
 		ctx := context.Background()
 		locker, tctx := initTLTest(t)
 		key := paths.FromKey("example", []byte("key"))
-		tx := data.NewTId()
+		tx := data.NewTID()
 		tctx.Monitor.BeginTx(ctx, tx)
 
 		// Initialize key.
@@ -125,7 +125,7 @@ func TestUnlockAfterCreateTimeout(t *testing.T) {
 		ctx := context.Background()
 		locker, tctx := initTLTest(t)
 		key := paths.FromKey("example", []byte("key"))
-		tx := data.NewTId()
+		tx := data.NewTID()
 		tctx.Monitor.BeginTx(ctx, tx)
 
 		// Locking will not succeed with an expired context.
@@ -146,7 +146,7 @@ func TestLockReadWrite(t *testing.T) {
 		ctx := context.Background()
 		locker, tctx := initTLTest(t)
 		key := paths.FromKey("example", []byte("key"))
-		tx := data.NewTId()
+		tx := data.NewTID()
 		tctx.Monitor.BeginTx(ctx, tx)
 
 		// Initialize key.
@@ -186,8 +186,8 @@ func TestLockMultipleR(t *testing.T) {
 		ctx := context.Background()
 		locker, tctx := initTLTest(t)
 		key := paths.FromKey("example", []byte("key"))
-		tx1 := data.NewTId()
-		tx2 := data.NewTId()
+		tx1 := data.NewTID()
+		tx2 := data.NewTID()
 		tctx.Monitor.BeginTx(ctx, tx1)
 		tctx.Monitor.BeginTx(ctx, tx2)
 
@@ -409,7 +409,7 @@ func TestLockUpgrade(t *testing.T) {
 		ctx := context.Background()
 		locker, tctx := initTLTest(t)
 		key := paths.FromKey("example", []byte("key"))
-		tx := data.NewTId()
+		tx := data.NewTID()
 		tctx.Monitor.BeginTx(ctx, tx)
 
 		// Initialize key.
@@ -437,10 +437,10 @@ func TestLockUpgradeWait(t *testing.T) {
 		ctx := context.Background()
 		locker, tctx := initTLTest(t)
 		key := paths.FromKey("example", []byte("key"))
-		tx := data.NewTId()
+		tx := data.NewTID()
 		tctx.Monitor.BeginTx(ctx, tx)
 
-		txr := data.NewTId()
+		txr := data.NewTID()
 		tctx.Monitor.BeginTx(ctx, txr)
 
 		// Initialize key.
@@ -491,7 +491,7 @@ func TestLockReadRemote(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Lock the key from locker2.
-		tx2 := data.NewTId()
+		tx2 := data.NewTID()
 		tctx2.Monitor.BeginTx(ctx, tx2)
 		err = locker2.LockRead(ctx, key, tx2)
 		assert.NoError(t, err)
@@ -501,7 +501,7 @@ func TestLockReadRemote(t *testing.T) {
 		})
 
 		// Lock it from locker1 as well.
-		tx1 := data.NewTId()
+		tx1 := data.NewTID()
 		tctx1.Monitor.BeginTx(ctx, tx1)
 		err = locker1.LockRead(ctx, key, tx1)
 		assert.NoError(t, err)
@@ -529,7 +529,7 @@ func TestWaitRemote(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Lock in write from locker2.
-		tx2 := data.NewTId()
+		tx2 := data.NewTID()
 		tctx2.Monitor.BeginTx(ctx, tx2)
 		err = locker2.LockWrite(ctx, key, tx2)
 		assert.NoError(t, err)
@@ -547,7 +547,7 @@ func TestWaitRemote(t *testing.T) {
 		})
 
 		// Lock in write from locker1.
-		tx1 := data.NewTId()
+		tx1 := data.NewTID()
 		tctx1.Monitor.BeginTx(ctx, tx1)
 		err = locker1.LockWrite(ctx, key, tx1)
 		assert.NoError(t, err)


### PR DESCRIPTION
FuzzConcurrentTx found a strict-serializability violation: concurrent increments to a key could be lost. When a writer commits via the single-RW fast path it writes no transaction log, so Monitor.CommittedValue cannot resolve its value. Validation (validateLockedRead / validateReadNotFound) nonetheless cached a guessed value paired with that writer's ID, producing a cache entry whose value bytes and writer tag came from different versions. A later single-RW commit trusted it (writer tag matched the live last-writer) and clobbered a newer value.

Only refresh the local cache when CommittedValue resolves authoritatively (Status OK and written); otherwise invalidate and let the retry re-read the authoritative value from storage.

Also make FuzzConcurrentTx deterministic so the bug could be diagnosed and regression-tested:
- Injectable tx-ID prefix source (data.NewTIDFromSource / RenewTIDFromSource, trans.CtxWithIDSource); production still uses crypto/rand and priority still comes from the clock.
- Sort commit-path slices built from maps (initValidation, collectionsLocks, tlocker.LockedPaths) so backend-op order is stable.
- Disable backoff jitter (RandomizationFactor = 0), which used the global RNG.
- Use a private ctxKey type so the two trans context keys no longer collide.

See docs/adr/007-single-rw-cache-lost-update.md. After the fix, a 120k-schedule replay and a ~1.1M-exec fuzz run pass.